### PR TITLE
feat: 문서/인터뷰 목록 API 페이지네이션 추가 (closes #1)

### DIFF
--- a/src/main/java/com/interviewai/backend/document/controller/DocumentController.java
+++ b/src/main/java/com/interviewai/backend/document/controller/DocumentController.java
@@ -8,13 +8,15 @@ import com.interviewai.backend.document.service.DocumentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Tag(name = "Document", description = "문서 관리 API")
 @RestController
@@ -35,9 +37,10 @@ public class DocumentController {
 
     @Operation(summary = "내 문서 목록 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<DocumentListResponseDto>>> getMyDocuments(
-            @AuthenticationPrincipal Long userId) {
-        return ResponseEntity.ok(ApiResponse.ok(documentService.findMyDocuments(userId)));
+    public ResponseEntity<ApiResponse<Page<DocumentListResponseDto>>> getMyDocuments(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(documentService.findMyDocuments(userId, pageable)));
     }
 
     @Operation(summary = "문서 삭제")

--- a/src/main/java/com/interviewai/backend/document/repository/UserDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/document/repository/UserDocumentRepository.java
@@ -1,6 +1,8 @@
 package com.interviewai.backend.document.repository;
 
 import com.interviewai.backend.document.model.UserDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,6 +11,8 @@ import java.util.Optional;
 public interface UserDocumentRepository extends JpaRepository<UserDocument, Long> {
 
     List<UserDocument> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Page<UserDocument> findByUserId(Long userId, Pageable pageable);
 
     Optional<UserDocument> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/interviewai/backend/document/service/DocumentService.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentService.java
@@ -3,15 +3,15 @@ package com.interviewai.backend.document.service;
 import com.interviewai.backend.document.controller.dto.DocumentListResponseDto;
 import com.interviewai.backend.document.controller.dto.DocumentUploadResponseDto;
 import com.interviewai.backend.document.enums.DocumentType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 public interface DocumentService {
 
     DocumentUploadResponseDto uploadDocument(Long userId, MultipartFile file, DocumentType documentType);
 
-    List<DocumentListResponseDto> findMyDocuments(Long userId);
+    Page<DocumentListResponseDto> findMyDocuments(Long userId, Pageable pageable);
 
     void deleteDocument(Long userId, Long documentId);
 }

--- a/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
@@ -13,11 +13,11 @@ import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -58,11 +58,9 @@ public class DocumentServiceImpl implements DocumentService {
     }
 
     @Override
-    public List<DocumentListResponseDto> findMyDocuments(Long userId) {
-        return userDocumentRepository.findByUserIdOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(DocumentListResponseDto::from)
-                .toList();
+    public Page<DocumentListResponseDto> findMyDocuments(Long userId, Pageable pageable) {
+        return userDocumentRepository.findByUserId(userId, pageable)
+                .map(DocumentListResponseDto::from);
     }
 
     @Override

--- a/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
@@ -7,6 +7,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -48,9 +52,10 @@ public class InterviewController {
 
     @Operation(summary = "내 면접 이력 목록")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<InterviewSessionResponseDto>>> getMySessions(
-            @AuthenticationPrincipal Long userId) {
-        return ResponseEntity.ok(ApiResponse.ok(interviewService.findMySessions(userId)));
+    public ResponseEntity<ApiResponse<Page<InterviewSessionResponseDto>>> getMySessions(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(interviewService.findMySessions(userId, pageable)));
     }
 
     @Operation(summary = "면접 대화 내용 조회")

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionRepository.java
@@ -1,6 +1,8 @@
 package com.interviewai.backend.interview.repository;
 
 import com.interviewai.backend.interview.model.InterviewSession;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,6 +11,8 @@ import java.util.Optional;
 public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long> {
 
     List<InterviewSession> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Page<InterviewSession> findByUserId(Long userId, Pageable pageable);
 
     Optional<InterviewSession> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
@@ -1,6 +1,8 @@
 package com.interviewai.backend.interview.service;
 
 import com.interviewai.backend.interview.controller.dto.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -12,7 +14,7 @@ public interface InterviewService {
 
     InterviewFeedbackResponseDto finishInterview(Long userId, Long sessionId);
 
-    List<InterviewSessionResponseDto> findMySessions(Long userId);
+    Page<InterviewSessionResponseDto> findMySessions(Long userId, Pageable pageable);
 
     List<InterviewMessageResponseDto> findSessionMessages(Long userId, Long sessionId);
 

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -23,6 +23,8 @@ import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -154,11 +156,9 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
-    public List<InterviewSessionResponseDto> findMySessions(Long userId) {
-        return interviewSessionRepository.findByUserIdOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(InterviewSessionResponseDto::from)
-                .toList();
+    public Page<InterviewSessionResponseDto> findMySessions(Long userId, Pageable pageable) {
+        return interviewSessionRepository.findByUserId(userId, pageable)
+                .map(InterviewSessionResponseDto::from);
     }
 
     @Override

--- a/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
@@ -2,6 +2,7 @@ package com.interviewai.backend.document.service;
 
 import com.interviewai.backend.client.PdfParserClient;
 import com.interviewai.backend.common.exception.BusinessException;
+import com.interviewai.backend.document.controller.dto.DocumentListResponseDto;
 import com.interviewai.backend.document.enums.DocumentErrorCode;
 import com.interviewai.backend.document.enums.DocumentType;
 import com.interviewai.backend.document.model.UserDocument;
@@ -17,13 +18,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,8 +74,6 @@ class DocumentServiceImplTest {
                 "invalid content".getBytes()
         );
 
-        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-
         // when & then
         assertThatThrownBy(() -> documentService.uploadDocument(userId, invalidFile, DocumentType.RESUME))
                 .isInstanceOf(BusinessException.class)
@@ -106,6 +111,52 @@ class DocumentServiceImplTest {
         assertThat(response).isNotNull();
         assertThat(response.getDocumentType()).isEqualTo(DocumentType.RESUME);
         assertThat(response.getOriginalFileName()).isEqualTo("resume.pdf");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_문서_목록을_페이지네이션으로_조회한다")
+    void 기능_테스트_문서_목록을_페이지네이션으로_조회한다() {
+        // given
+        Long userId = 1L;
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        UserDocument document = UserDocument.builder()
+                .user(testUser)
+                .documentType(DocumentType.RESUME)
+                .originalFileName("resume.pdf")
+                .parsedText("이력서 내용")
+                .build();
+
+        Page<UserDocument> documentPage = new PageImpl<>(List.of(document), pageable, 1);
+        given(userDocumentRepository.findByUserId(eq(userId), eq(pageable))).willReturn(documentPage);
+
+        // when
+        Page<DocumentListResponseDto> result = documentService.findMyDocuments(userId, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getDocumentType()).isEqualTo(DocumentType.RESUME);
+        assertThat(result.getContent().get(0).getOriginalFileName()).isEqualTo("resume.pdf");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_문서가_없을_때_빈_페이지를_반환한다")
+    void 기능_테스트_문서가_없을_때_빈_페이지를_반환한다() {
+        // given
+        Long userId = 1L;
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        given(userDocumentRepository.findByUserId(eq(userId), eq(pageable)))
+                .willReturn(Page.empty(pageable));
+
+        // when
+        Page<DocumentListResponseDto> result = documentService.findMyDocuments(userId, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getContent()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -24,6 +24,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +35,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -168,6 +173,52 @@ class InterviewServiceImplTest {
         assertThatThrownBy(() -> interviewService.sendMessage(userId, sessionId, request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("완료");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_면접_세션_목록을_페이지네이션으로_조회한다")
+    void 기능_테스트_면접_세션_목록을_페이지네이션으로_조회한다() {
+        // given
+        Long userId = 1L;
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .jobTitle("백엔드 개발자")
+                .build();
+
+        Page<InterviewSession> sessionPage = new PageImpl<>(List.of(session), pageable, 1);
+        given(interviewSessionRepository.findByUserId(eq(userId), eq(pageable))).willReturn(sessionPage);
+
+        // when
+        Page<InterviewSessionResponseDto> result = interviewService.findMySessions(userId, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getMode()).isEqualTo(InterviewMode.BASIC);
+        assertThat(result.getContent().get(0).getLevel()).isEqualTo(InterviewLevel.JUNIOR);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_면접_세션이_없을_때_빈_페이지를_반환한다")
+    void 기능_테스트_면접_세션이_없을_때_빈_페이지를_반환한다() {
+        // given
+        Long userId = 1L;
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        given(interviewSessionRepository.findByUserId(eq(userId), eq(pageable)))
+                .willReturn(Page.empty(pageable));
+
+        // when
+        Page<InterviewSessionResponseDto> result = interviewService.findMySessions(userId, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getContent()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
- UserDocumentRepository, InterviewSessionRepository에 Pageable 기반 메서드 추가
- DocumentService, InterviewService 인터페이스 시그니처 Page<T> 반환으로 변경
- DocumentController, InterviewController에 @PageableDefault 파라미터 적용 (size=10, sort=createdAt DESC)
- 기존 불필요한 stubbing 제거 및 페이지네이션 테스트 4건 추가