### PR TITLE
Feat/interview cancel

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
@@ -73,4 +73,13 @@ public class InterviewController {
             @PathVariable Long sessionId) {
         return ResponseEntity.ok(ApiResponse.ok(interviewService.findFeedback(userId, sessionId)));
     }
+
+    @Operation(summary = "면접 취소")
+    @PatchMapping("/{sessionId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancelInterview(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId) {
+        interviewService.cancelInterview(userId, sessionId);
+        return ResponseEntity.ok(ApiResponse.ok(null, "면접이 취소되었습니다."));
+    }
 }

--- a/src/main/java/com/interviewai/backend/interview/enums/InterviewErrorCode.java
+++ b/src/main/java/com/interviewai/backend/interview/enums/InterviewErrorCode.java
@@ -13,7 +13,8 @@ public enum InterviewErrorCode implements ErrorCode {
     SESSION_ALREADY_COMPLETED("I002", "이미 완료된 면접 세션입니다.", HttpStatus.BAD_REQUEST),
     INVALID_INTERVIEW_MODE("I003", "잘못된 면접 모드입니다.", HttpStatus.BAD_REQUEST),
     FEEDBACK_NOT_FOUND("I004", "피드백을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    DOCUMENT_REQUIRED("I005", "이 면접 모드에서는 문서가 필요합니다.", HttpStatus.BAD_REQUEST);
+    DOCUMENT_REQUIRED("I005", "이 면접 모드에서는 문서가 필요합니다.", HttpStatus.BAD_REQUEST),
+    SESSION_CANNOT_CANCEL("I006", "진행 중인 면접 세션만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
@@ -19,4 +19,6 @@ public interface InterviewService {
     List<InterviewMessageResponseDto> findSessionMessages(Long userId, Long sessionId);
 
     InterviewFeedbackResponseDto findFeedback(Long userId, Long sessionId);
+
+    void cancelInterview(Long userId, Long sessionId);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -156,6 +156,19 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
+    @Transactional
+    public void cancelInterview(Long userId, Long sessionId) {
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(InterviewErrorCode.SESSION_NOT_FOUND));
+
+        if (session.getStatus() != InterviewStatus.IN_PROGRESS) {
+            throw new BusinessException(InterviewErrorCode.SESSION_CANNOT_CANCEL);
+        }
+
+        session.cancel();
+    }
+
+    @Override
     public Page<InterviewSessionResponseDto> findMySessions(Long userId, Pageable pageable) {
         return interviewSessionRepository.findByUserId(userId, pageable)
                 .map(InterviewSessionResponseDto::from);

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -244,6 +244,91 @@ class InterviewServiceImplTest {
                 .hasMessageContaining("피드백");
     }
 
+    @Test
+    @DisplayName("기능_테스트_진행_중인_면접_세션을_취소한다")
+    void 기능_테스트_진행_중인_면접_세션을_취소한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+
+        // when
+        interviewService.cancelInterview(userId, sessionId);
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(com.interviewai.backend.interview.enums.InterviewStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_완료된_면접_세션을_취소하면_예외가_발생한다")
+    void 예외_테스트_완료된_면접_세션을_취소하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        session.complete();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.cancelInterview(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("취소");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_이미_취소된_면접_세션을_취소하면_예외가_발생한다")
+    void 예외_테스트_이미_취소된_면접_세션을_취소하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        session.cancel();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.cancelInterview(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("취소");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_세션을_취소하면_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_세션을_취소하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.cancelInterview(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## 변경 사항                                                                                                                                                                                                                         
  - InterviewErrorCode에 SESSION_CANNOT_CANCEL(I006) 추가
  - InterviewService 인터페이스에 cancelInterview 메서드 추가
  - InterviewServiceImpl에 취소 로직 구현 (IN_PROGRESS 상태만 취소 가능)
  - PATCH /api/interviews/{id}/cancel 엔드포인트 추가
  - 취소 관련 테스트 4건 추가

  ## 테스트
  ./gradlew test BUILD SUCCESSFUL