### PR TITLE
feat: 사용자별 인터뷰 통계 API 추가 (closes #4)

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
@@ -73,4 +73,11 @@ public class InterviewController {
             @PathVariable Long sessionId) {
         return ResponseEntity.ok(ApiResponse.ok(interviewService.findFeedback(userId, sessionId)));
     }
+
+    @Operation(summary = "내 면접 통계 조회")
+    @GetMapping("/stats")
+    public ResponseEntity<ApiResponse<InterviewStatsResponseDto>> getMyStats(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(ApiResponse.ok(interviewService.getMyStats(userId)));
+    }
 }

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStatsResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStatsResponseDto.java
@@ -1,0 +1,18 @@
+package com.interviewai.backend.interview.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class InterviewStatsResponseDto {
+
+    private long totalCount;
+    private long completedCount;
+    private long cancelledCount;
+    private Double averageScore;
+    private Map<String, Long> modeDistribution;
+    private Map<String, Long> levelDistribution;
+}

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
@@ -2,10 +2,14 @@ package com.interviewai.backend.interview.repository;
 
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface InterviewFeedbackRepository extends JpaRepository<InterviewFeedback, Long> {
 
     Optional<InterviewFeedback> findBySessionId(Long sessionId);
+
+    @Query("SELECT AVG(f.overallScore) FROM InterviewFeedback f WHERE f.session.user.id = :userId")
+    Double findAverageScoreByUserId(Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionRepository.java
@@ -1,5 +1,8 @@
 package com.interviewai.backend.interview.repository;
 
+import com.interviewai.backend.interview.enums.InterviewLevel;
+import com.interviewai.backend.interview.enums.InterviewMode;
+import com.interviewai.backend.interview.enums.InterviewStatus;
 import com.interviewai.backend.interview.model.InterviewSession;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,4 +18,12 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
     Page<InterviewSession> findByUserId(Long userId, Pageable pageable);
 
     Optional<InterviewSession> findByIdAndUserId(Long id, Long userId);
+
+    long countByUserId(Long userId);
+
+    long countByUserIdAndStatus(Long userId, InterviewStatus status);
+
+    long countByUserIdAndMode(Long userId, InterviewMode mode);
+
+    long countByUserIdAndLevel(Long userId, InterviewLevel level);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
@@ -19,4 +19,6 @@ public interface InterviewService {
     List<InterviewMessageResponseDto> findSessionMessages(Long userId, Long sessionId);
 
     InterviewFeedbackResponseDto findFeedback(Long userId, Long sessionId);
+
+    InterviewStatsResponseDto getMyStats(Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -9,6 +9,7 @@ import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.document.repository.UserDocumentRepository;
 import com.interviewai.backend.interview.controller.dto.*;
 import com.interviewai.backend.interview.enums.InterviewErrorCode;
+import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.InterviewMode;
 import com.interviewai.backend.interview.enums.InterviewStatus;
 import com.interviewai.backend.interview.enums.MessageRole;
@@ -181,6 +182,33 @@ public class InterviewServiceImpl implements InterviewService {
                 .orElseThrow(() -> new BusinessException(InterviewErrorCode.FEEDBACK_NOT_FOUND));
 
         return InterviewFeedbackResponseDto.from(feedback);
+    }
+
+    @Override
+    public InterviewStatsResponseDto getMyStats(Long userId) {
+        long totalCount = interviewSessionRepository.countByUserId(userId);
+        long completedCount = interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.COMPLETED);
+        long cancelledCount = interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.CANCELLED);
+        Double averageScore = interviewFeedbackRepository.findAverageScoreByUserId(userId);
+
+        java.util.Map<String, Long> modeDistribution = new java.util.LinkedHashMap<>();
+        for (InterviewMode mode : InterviewMode.values()) {
+            modeDistribution.put(mode.name(), interviewSessionRepository.countByUserIdAndMode(userId, mode));
+        }
+
+        java.util.Map<String, Long> levelDistribution = new java.util.LinkedHashMap<>();
+        for (InterviewLevel level : InterviewLevel.values()) {
+            levelDistribution.put(level.name(), interviewSessionRepository.countByUserIdAndLevel(userId, level));
+        }
+
+        return InterviewStatsResponseDto.builder()
+                .totalCount(totalCount)
+                .completedCount(completedCount)
+                .cancelledCount(cancelledCount)
+                .averageScore(averageScore)
+                .modeDistribution(modeDistribution)
+                .levelDistribution(levelDistribution)
+                .build();
     }
 
     private void validateModeRequirements(InterviewStartRequestDto request) {

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -244,6 +244,65 @@ class InterviewServiceImplTest {
                 .hasMessageContaining("피드백");
     }
 
+    @Test
+    @DisplayName("기능_테스트_인터뷰_통계를_조회한다")
+    void 기능_테스트_인터뷰_통계를_조회한다() {
+        // given
+        Long userId = 1L;
+
+        given(interviewSessionRepository.countByUserId(userId)).willReturn(10L);
+        given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.COMPLETED)).willReturn(7L);
+        given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.CANCELLED)).willReturn(2L);
+        given(interviewFeedbackRepository.findAverageScoreByUserId(userId)).willReturn(78.5);
+
+        given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.BASIC)).willReturn(5L);
+        given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.RESUME)).willReturn(3L);
+        given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.COMPANY)).willReturn(2L);
+
+        given(interviewSessionRepository.countByUserIdAndLevel(userId, InterviewLevel.JUNIOR)).willReturn(6L);
+        given(interviewSessionRepository.countByUserIdAndLevel(userId, InterviewLevel.SENIOR)).willReturn(4L);
+
+        // when
+        InterviewStatsResponseDto result = interviewService.getMyStats(userId);
+
+        // then
+        assertThat(result.getTotalCount()).isEqualTo(10L);
+        assertThat(result.getCompletedCount()).isEqualTo(7L);
+        assertThat(result.getCancelledCount()).isEqualTo(2L);
+        assertThat(result.getAverageScore()).isEqualTo(78.5);
+        assertThat(result.getModeDistribution()).containsEntry("BASIC", 5L);
+        assertThat(result.getModeDistribution()).containsEntry("RESUME", 3L);
+        assertThat(result.getModeDistribution()).containsEntry("COMPANY", 2L);
+        assertThat(result.getLevelDistribution()).containsEntry("JUNIOR", 6L);
+        assertThat(result.getLevelDistribution()).containsEntry("SENIOR", 4L);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_피드백이_없을때_평균점수가_null이다")
+    void 기능_테스트_피드백이_없을때_평균점수가_null이다() {
+        // given
+        Long userId = 1L;
+
+        given(interviewSessionRepository.countByUserId(userId)).willReturn(0L);
+        given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.COMPLETED)).willReturn(0L);
+        given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.CANCELLED)).willReturn(0L);
+        given(interviewFeedbackRepository.findAverageScoreByUserId(userId)).willReturn(null);
+
+        given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.BASIC)).willReturn(0L);
+        given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.RESUME)).willReturn(0L);
+        given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.COMPANY)).willReturn(0L);
+
+        given(interviewSessionRepository.countByUserIdAndLevel(userId, InterviewLevel.JUNIOR)).willReturn(0L);
+        given(interviewSessionRepository.countByUserIdAndLevel(userId, InterviewLevel.SENIOR)).willReturn(0L);
+
+        // when
+        InterviewStatsResponseDto result = interviewService.getMyStats(userId);
+
+        // then
+        assertThat(result.getTotalCount()).isZero();
+        assertThat(result.getAverageScore()).isNull();
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## 변경 사항
- InterviewSessionRepository에 countByUserId, countByUserIdAndStatus/Mode/Level 쿼리 추가
- InterviewFeedbackRepository에 findAverageScoreByUserId JPQL 쿼리 추가
- InterviewStatsResponseDto 추가 (totalCount, completedCount, cancelledCount, averageScore, modeDistribution, levelDistribution)
- InterviewService 인터페이스에 getMyStats 메서드 추가
- InterviewServiceImpl에 통계 집계 로직 구현
- GET /api/interviews/stats 엔드포인트 추가
- 통계 조회 테스트 2건 추가

## 커밋 구조
```
feat: InterviewSessionRepository, InterviewFeedbackRepository에 통계 쿼리 추가 (closes #4)
feat: InterviewStatsResponseDto 추가
feat: InterviewService 인터페이스에 getMyStats 메서드 추가
feat: InterviewServiceImpl에 getMyStats 구현
feat: InterviewController에 GET /interviews/stats 엔드포인트 추가
test: 인터뷰 통계 테스트 추가
```

## 테스트
`./gradlew test` BUILD SUCCESSFUL