### PR TITLE
feat: DocumentType에 CAREER_STATEMENT(경력기술서) 추가

### DIFF
--- a/src/main/java/com/interviewai/backend/document/enums/DocumentType.java
+++ b/src/main/java/com/interviewai/backend/document/enums/DocumentType.java
@@ -1,5 +1,5 @@
 package com.interviewai.backend.document.enums;
 
 public enum DocumentType {
-    RESUME, PORTFOLIO
+    RESUME, PORTFOLIO, CAREER_STATEMENT
 }


### PR DESCRIPTION
## Summary
- `DocumentType` enum에 `CAREER_STATEMENT`(경력기술서) 추가
- 기존 `RESUME`, `PORTFOLIO`와 함께 총 3가지 타입 지원
- 업로드는 선택적 — 하나만 해도 되고 아예 안 해도 됨

## Test plan
- [x] 기존 테스트 전부 통과 확인
- [x] DB는 varchar 저장이므로 마이그레이션 불필요

Closes #10