### PR TITLE
fix: PDF 업로드 500 에러 수정 (catch Throwable + MaxUploadSizeExceededException)

### DIFF
--- a/src/main/java/com/interviewai/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/interviewai/backend/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -27,6 +28,19 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(new ErrorCode() {
                     public String getCode() { return "VALIDATION_ERROR"; }
                     public String getMessage() { return message; }
+                    public org.springframework.http.HttpStatus getHttpStatus() {
+                        return org.springframework.http.HttpStatus.BAD_REQUEST;
+                    }
+                }));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.warn("파일 크기 초과: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(new ErrorCode() {
+                    public String getCode() { return "FILE_TOO_LARGE"; }
+                    public String getMessage() { return "파일 크기가 너무 큽니다."; }
                     public org.springframework.http.HttpStatus getHttpStatus() {
                         return org.springframework.http.HttpStatus.BAD_REQUEST;
                     }

--- a/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
@@ -42,8 +42,8 @@ public class DocumentServiceImpl implements DocumentService {
         String parsedText;
         try {
             parsedText = pdfParserClient.parse(file);
-        } catch (Exception e) {
-            log.error("PDF 파싱 실패: {}", e.getMessage());
+        } catch (Throwable e) {
+            log.error("PDF 파싱 실패: {}", e.getMessage(), e);
             throw new BusinessException(DocumentErrorCode.FILE_PARSE_FAILED);
         }
 


### PR DESCRIPTION
## Summary
- `DocumentServiceImpl`: `catch (Exception e)` → `catch (Throwable e)` — Java Error 계열(OutOfMemoryError 등)도 `BusinessException(FILE_PARSE_FAILED)`으로 변환
- `GlobalExceptionHandler`: `MaxUploadSizeExceededException` 핸들러 추가 — 파일 크기 초과 시 500 → 400 + `FILE_TOO_LARGE`

closes #12

## Test plan
- [ ] 정상 PDF 업로드 성공 확인
- [ ] 허용 크기 초과 파일 업로드 시 400 `FILE_TOO_LARGE` 반환 확인
- [ ] PDF 파싱 실패 시 `FILE_PARSE_FAILED` 반환 확인
