### PR TITLE
refactor: 문서 업로드 API 개선 — documentType 복원, updateDocumentType 추가, 파일 크기 제한 설정

### DIFF
--- a/src/main/java/com/interviewai/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/interviewai/backend/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
@@ -28,6 +29,19 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(new ErrorCode() {
                     public String getCode() { return "VALIDATION_ERROR"; }
                     public String getMessage() { return message; }
+                    public org.springframework.http.HttpStatus getHttpStatus() {
+                        return org.springframework.http.HttpStatus.BAD_REQUEST;
+                    }
+                }));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.warn("MethodArgumentTypeMismatchException: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(new ErrorCode() {
+                    public String getCode() { return "INVALID_PARAMETER"; }
+                    public String getMessage() { return "잘못된 파라미터 값입니다: " + e.getName(); }
                     public org.springframework.http.HttpStatus getHttpStatus() {
                         return org.springframework.http.HttpStatus.BAD_REQUEST;
                     }

--- a/src/main/java/com/interviewai/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/interviewai/backend/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.interviewai.backend.common.exception;
 
 import com.interviewai.backend.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -55,6 +56,19 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(new ErrorCode() {
                     public String getCode() { return "FILE_TOO_LARGE"; }
                     public String getMessage() { return "파일 크기가 너무 큽니다."; }
+                    public org.springframework.http.HttpStatus getHttpStatus() {
+                        return org.springframework.http.HttpStatus.BAD_REQUEST;
+                    }
+                }));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.warn("DataIntegrityViolationException: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(new ErrorCode() {
+                    public String getCode() { return "DATA_INTEGRITY_ERROR"; }
+                    public String getMessage() { return "데이터 처리 중 오류가 발생했습니다."; }
                     public org.springframework.http.HttpStatus getHttpStatus() {
                         return org.springframework.http.HttpStatus.BAD_REQUEST;
                     }

--- a/src/main/java/com/interviewai/backend/document/controller/DocumentController.java
+++ b/src/main/java/com/interviewai/backend/document/controller/DocumentController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+
 @Tag(name = "Document", description = "문서 관리 API")
 @RestController
 @RequestMapping("/api/documents")
@@ -31,8 +32,18 @@ public class DocumentController {
     public ResponseEntity<ApiResponse<DocumentUploadResponseDto>> uploadDocument(
             @AuthenticationPrincipal Long userId,
             @RequestParam("file") MultipartFile file,
-            @RequestParam("documentType") DocumentType documentType) {
+            @RequestParam(value = "documentType", required = false, defaultValue = "RESUME") DocumentType documentType) {
         return ResponseEntity.ok(ApiResponse.ok(documentService.uploadDocument(userId, file, documentType)));
+    }
+
+    @Operation(summary = "문서 유형 변경")
+    @PatchMapping("/{documentId}/type")
+    public ResponseEntity<ApiResponse<Void>> updateDocumentType(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long documentId,
+            @RequestParam DocumentType documentType) {
+        documentService.updateDocumentType(userId, documentId, documentType);
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @Operation(summary = "내 문서 목록 조회")

--- a/src/main/java/com/interviewai/backend/document/enums/DocumentErrorCode.java
+++ b/src/main/java/com/interviewai/backend/document/enums/DocumentErrorCode.java
@@ -12,7 +12,7 @@ public enum DocumentErrorCode implements ErrorCode {
     DOCUMENT_NOT_FOUND("D001", "문서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     UNSUPPORTED_FILE_TYPE("D002", "지원하지 않는 파일 형식입니다. PDF 파일만 허용됩니다.", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_FAILED("D003", "파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    FILE_PARSE_FAILED("D004", "파일 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    FILE_PARSE_FAILED("D004", "파일 파싱에 실패했습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/document/model/UserDocument.java
+++ b/src/main/java/com/interviewai/backend/document/model/UserDocument.java
@@ -46,4 +46,8 @@ public class UserDocument {
     public void updateParsedText(String parsedText) {
         this.parsedText = parsedText;
     }
+
+    public void updateDocumentType(DocumentType documentType) {
+        this.documentType = documentType;
+    }
 }

--- a/src/main/java/com/interviewai/backend/document/service/DocumentService.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentService.java
@@ -14,4 +14,6 @@ public interface DocumentService {
     Page<DocumentListResponseDto> findMyDocuments(Long userId, Pageable pageable);
 
     void deleteDocument(Long userId, Long documentId);
+
+    void updateDocumentType(Long userId, Long documentId, DocumentType documentType);
 }

--- a/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
@@ -41,7 +41,7 @@ public class DocumentServiceImpl implements DocumentService {
 
         String parsedText;
         try {
-            parsedText = pdfParserClient.parse(file);
+            parsedText = pdfParserClient.parse(file).replace("\u0000", "");
         } catch (Throwable e) {
             log.error("PDF 파싱 실패: {}", e.getMessage(), e);
             throw new BusinessException(DocumentErrorCode.FILE_PARSE_FAILED);

--- a/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
@@ -72,6 +72,15 @@ public class DocumentServiceImpl implements DocumentService {
         userDocumentRepository.delete(document);
     }
 
+    @Override
+    @Transactional
+    public void updateDocumentType(Long userId, Long documentId, DocumentType documentType) {
+        UserDocument document = userDocumentRepository.findByIdAndUserId(documentId, userId)
+                .orElseThrow(() -> new BusinessException(DocumentErrorCode.DOCUMENT_NOT_FOUND));
+
+        document.updateDocumentType(documentType);
+    }
+
     private void validatePdfFile(MultipartFile file) {
         String contentType = file.getContentType();
         String originalFilename = file.getOriginalFilename();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,11 @@ spring:
         options:
           model: claude-sonnet-4-6
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 50MB
+
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,8 @@ spring:
 
 server:
   port: 8080
+  tomcat:
+    max-post-size: 50MB
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
@@ -27,11 +27,14 @@ import org.springframework.mock.web.MockMultipartFile;
 import java.util.List;
 import java.util.Optional;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class DocumentServiceImplTest {
@@ -111,6 +114,34 @@ class DocumentServiceImplTest {
         assertThat(response).isNotNull();
         assertThat(response.getDocumentType()).isEqualTo(DocumentType.RESUME);
         assertThat(response.getOriginalFileName()).isEqualTo("resume.pdf");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_parsedText의_null_바이트를_제거하고_저장한다")
+    void 기능_테스트_parsedText의_null_바이트를_제거하고_저장한다() throws Exception {
+        // given
+        Long userId = 1L;
+        MockMultipartFile pdfFile = new MockMultipartFile(
+                "file", "resume.pdf", "application/pdf", "pdf content".getBytes());
+        String textWithNullBytes = "이력서\u0000내용\u0000";
+        UserDocument savedDocument = UserDocument.builder()
+                .user(testUser)
+                .documentType(DocumentType.RESUME)
+                .originalFileName("resume.pdf")
+                .parsedText("이력서내용")
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(pdfParserClient.parse(any())).willReturn(textWithNullBytes);
+        given(userDocumentRepository.save(any(UserDocument.class))).willReturn(savedDocument);
+
+        // when
+        documentService.uploadDocument(userId, pdfFile, DocumentType.RESUME);
+
+        // then
+        ArgumentCaptor<UserDocument> captor = ArgumentCaptor.forClass(UserDocument.class);
+        verify(userDocumentRepository).save(captor.capture());
+        assertThat(captor.getValue().getParsedText()).doesNotContain("\u0000");
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
@@ -174,4 +174,43 @@ class DocumentServiceImplTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(DocumentErrorCode.DOCUMENT_NOT_FOUND));
     }
+
+    @Test
+    @DisplayName("기능_테스트_문서_유형을_변경한다")
+    void 기능_테스트_문서_유형을_변경한다() {
+        // given
+        Long userId = 1L;
+        Long documentId = 1L;
+
+        UserDocument document = UserDocument.builder()
+                .user(testUser)
+                .documentType(DocumentType.RESUME)
+                .originalFileName("resume.pdf")
+                .parsedText("이력서 내용")
+                .build();
+
+        given(userDocumentRepository.findByIdAndUserId(documentId, userId)).willReturn(Optional.of(document));
+
+        // when
+        documentService.updateDocumentType(userId, documentId, DocumentType.PORTFOLIO);
+
+        // then
+        assertThat(document.getDocumentType()).isEqualTo(DocumentType.PORTFOLIO);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_문서의_유형을_변경하면_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_문서의_유형을_변경하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long documentId = 999L;
+
+        given(userDocumentRepository.findByIdAndUserId(documentId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> documentService.updateDocumentType(userId, documentId, DocumentType.PORTFOLIO))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(DocumentErrorCode.DOCUMENT_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## Summary

- `application.yml`: multipart 파일 크기 제한 추가 (`max-file-size: 20MB`, `max-request-size: 50MB`) — 기존 기본값 1MB로 인한 FILE_TOO_LARGE 오류 수정
- `POST /api/documents`: `documentType` 파라미터 복원 (`required=false`, 기본값 `RESUME`)
- `PATCH /api/documents/{id}/type`: 업로드 후 문서 유형 변경 엔드포인트 추가
- `UserDocument`: `updateDocumentType()` 메서드 추가
- `GlobalExceptionHandler`: `MethodArgumentTypeMismatchException` 핸들러 추가 (400 INVALID_PARAMETER)
- `GlobalExceptionHandler`: `DataIntegrityViolationException` 핸들러 추가 — null byte 포함 텍스트로 인한 DB 저장 오류 방지
- `DocumentServiceImpl`: PDF 파싱 후 `parsedText`에서 null byte(`\u0000`) 제거 처리
- `FILE_PARSE_FAILED`: HttpStatus `INTERNAL_SERVER_ERROR` → `BAD_REQUEST` 수정

Closes #14

## Test plan

- [x] `./gradlew test` 전체 통과 확인
- [x] `./gradlew build` 빌드 성공 확인
- [x] 20MB 이하 PDF 파일 정상 업로드 확인
- [x] `PATCH /api/documents/{id}/type?documentType=PORTFOLIO` 정상 동작 확인
- [x] 잘못된 documentType 값 전달 시 400 INVALID_PARAMETER 반환 확인
- [x] null byte 포함 PDF 업로드 시 정상 저장 확인