### PR TITLE
feat(#16): 인터뷰 시작 시 다중 문서 선택 지원

### DIFF
--- a/src/main/java/com/interviewai/backend/document/repository/UserDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/document/repository/UserDocumentRepository.java
@@ -15,4 +15,6 @@ public interface UserDocumentRepository extends JpaRepository<UserDocument, Long
     Page<UserDocument> findByUserId(Long userId, Pageable pageable);
 
     Optional<UserDocument> findByIdAndUserId(Long id, Long userId);
+
+    List<UserDocument> findAllByIdInAndUserId(List<Long> ids, Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class InterviewStartRequestDto {
@@ -18,7 +20,7 @@ public class InterviewStartRequestDto {
 
     private String jobTitle;
 
-    private Long documentId;
+    private List<Long> documentIds;
 
     private String jobPostingUrl;
 

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
@@ -1,6 +1,5 @@
 package com.interviewai.backend.interview.model;
 
-import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.InterviewMode;
 import com.interviewai.backend.interview.enums.InterviewStatus;
@@ -40,10 +39,6 @@ public class InterviewSession {
 
     private String jobTitle;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "document_id")
-    private UserDocument document;
-
     private String jobPostingUrl;
 
     @Column(columnDefinition = "TEXT")
@@ -59,14 +54,12 @@ public class InterviewSession {
 
     @Builder
     public InterviewSession(User user, InterviewMode mode, InterviewLevel level,
-                            String jobTitle, UserDocument document,
-                            String jobPostingUrl, String jobPostingContent) {
+                            String jobTitle, String jobPostingUrl, String jobPostingContent) {
         this.user = user;
         this.mode = mode;
         this.level = level;
         this.status = InterviewStatus.IN_PROGRESS;
         this.jobTitle = jobTitle;
-        this.document = document;
         this.jobPostingUrl = jobPostingUrl;
         this.jobPostingContent = jobPostingContent;
     }

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewSessionDocument.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewSessionDocument.java
@@ -1,0 +1,33 @@
+package com.interviewai.backend.interview.model;
+
+import com.interviewai.backend.document.model.UserDocument;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "interview_session_documents")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewSessionDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_session_id", nullable = false)
+    private InterviewSession session;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private UserDocument document;
+
+    @Builder
+    public InterviewSessionDocument(InterviewSession session, UserDocument document) {
+        this.session = session;
+        this.document = document;
+    }
+}

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
@@ -1,0 +1,11 @@
+package com.interviewai.backend.interview.repository;
+
+import com.interviewai.backend.interview.model.InterviewSessionDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterviewSessionDocumentRepository extends JpaRepository<InterviewSessionDocument, Long> {
+
+    List<InterviewSessionDocument> findBySessionId(Long sessionId);
+}

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -16,8 +16,10 @@ import com.interviewai.backend.interview.enums.MessageRole;
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.model.InterviewSessionDocument;
 import com.interviewai.backend.interview.repository.InterviewFeedbackRepository;
 import com.interviewai.backend.interview.repository.InterviewMessageRepository;
+import com.interviewai.backend.interview.repository.InterviewSessionDocumentRepository;
 import com.interviewai.backend.interview.repository.InterviewSessionRepository;
 import com.interviewai.backend.user.enums.UserErrorCode;
 import com.interviewai.backend.user.model.User;
@@ -29,6 +31,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -38,6 +41,7 @@ import java.util.List;
 public class InterviewServiceImpl implements InterviewService {
 
     private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewSessionDocumentRepository interviewSessionDocumentRepository;
     private final InterviewMessageRepository interviewMessageRepository;
     private final InterviewFeedbackRepository interviewFeedbackRepository;
     private final UserRepository userRepository;
@@ -54,10 +58,9 @@ public class InterviewServiceImpl implements InterviewService {
 
         validateModeRequirements(request);
 
-        UserDocument document = null;
-        if (request.getDocumentId() != null) {
-            document = userDocumentRepository.findByIdAndUserId(request.getDocumentId(), userId)
-                    .orElseThrow(() -> new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED));
+        List<UserDocument> documents = new ArrayList<>();
+        if (request.getDocumentIds() != null && !request.getDocumentIds().isEmpty()) {
+            documents = userDocumentRepository.findAllByIdInAndUserId(request.getDocumentIds(), userId);
         }
 
         String jobPostingContent = null;
@@ -75,13 +78,21 @@ public class InterviewServiceImpl implements InterviewService {
                 .mode(request.getMode())
                 .level(request.getLevel())
                 .jobTitle(request.getJobTitle())
-                .document(document)
                 .jobPostingUrl(request.getJobPostingUrl())
                 .jobPostingContent(jobPostingContent)
                 .build();
         session = interviewSessionRepository.save(session);
 
-        String systemPrompt = buildSystemPrompt(session, document, jobPostingContent, githubInfo);
+        for (UserDocument document : documents) {
+            interviewSessionDocumentRepository.save(
+                    InterviewSessionDocument.builder()
+                            .session(session)
+                            .document(document)
+                            .build()
+            );
+        }
+
+        String systemPrompt = buildSystemPrompt(session, documents, jobPostingContent, githubInfo);
         String firstQuestion = claudeAiClient.chat(systemPrompt, List.of(),
                 "면접을 시작해주세요. 첫 번째 질문을 해주세요.");
 
@@ -118,8 +129,11 @@ public class InterviewServiceImpl implements InterviewService {
                         msg.getContent()))
                 .toList();
 
-        UserDocument document = session.getDocument();
-        String systemPrompt = buildSystemPrompt(session, document, session.getJobPostingContent(), null);
+        List<UserDocument> documents = interviewSessionDocumentRepository.findBySessionId(sessionId)
+                .stream()
+                .map(InterviewSessionDocument::getDocument)
+                .toList();
+        String systemPrompt = buildSystemPrompt(session, documents, session.getJobPostingContent(), null);
         String aiResponse = claudeAiClient.chat(systemPrompt, history, request.getContent());
 
         interviewMessageRepository.save(InterviewMessage.builder()
@@ -225,17 +239,16 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     private void validateModeRequirements(InterviewStartRequestDto request) {
-        if (request.getMode() == InterviewMode.RESUME && request.getDocumentId() == null
-                && request.getGithubUrl() == null) {
+        boolean hasDocument = request.getDocumentIds() != null && !request.getDocumentIds().isEmpty();
+        if (request.getMode() == InterviewMode.RESUME && !hasDocument && request.getGithubUrl() == null) {
             throw new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED);
         }
-        if (request.getMode() == InterviewMode.COMPANY && request.getDocumentId() == null
-                && request.getGithubUrl() == null) {
+        if (request.getMode() == InterviewMode.COMPANY && !hasDocument && request.getGithubUrl() == null) {
             throw new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED);
         }
     }
 
-    private String buildSystemPrompt(InterviewSession session, UserDocument document,
+    private String buildSystemPrompt(InterviewSession session, List<UserDocument> documents,
                                      String jobPostingContent, String githubInfo) {
         StringBuilder prompt = new StringBuilder();
         String levelDescription = switch (session.getLevel()) {
@@ -259,11 +272,17 @@ public class InterviewServiceImpl implements InterviewService {
                 5. 면접 중에는 피드백이나 점수를 주지 않는다.
                 """);
 
-        if (document != null && document.getParsedText() != null) {
-            prompt.append("\n=== 지원자 이력서/포트폴리오 ===\n");
-            String parsedText = document.getParsedText();
-            if (parsedText.length() > 2000) {
-                parsedText = parsedText.substring(0, 2000) + "...";
+        for (UserDocument doc : documents) {
+            if (doc.getParsedText() == null) continue;
+            String docLabel = switch (doc.getDocumentType()) {
+                case RESUME -> "이력서";
+                case PORTFOLIO -> "포트폴리오";
+                case CAREER_STATEMENT -> "경력기술서";
+            };
+            prompt.append("\n=== 지원자 ").append(docLabel).append(" ===\n");
+            String parsedText = doc.getParsedText();
+            if (parsedText.length() > 1500) {
+                parsedText = parsedText.substring(0, 1500) + "...";
             }
             prompt.append(parsedText).append("\n");
         }

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -4,14 +4,18 @@ import com.interviewai.backend.client.ClaudeAiClient;
 import com.interviewai.backend.client.GithubApiClient;
 import com.interviewai.backend.client.JobCrawlerClient;
 import com.interviewai.backend.common.exception.BusinessException;
+import com.interviewai.backend.document.enums.DocumentType;
+import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.document.repository.UserDocumentRepository;
 import com.interviewai.backend.interview.controller.dto.*;
 import com.interviewai.backend.interview.enums.*;
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.model.InterviewSessionDocument;
 import com.interviewai.backend.interview.repository.InterviewFeedbackRepository;
 import com.interviewai.backend.interview.repository.InterviewMessageRepository;
+import com.interviewai.backend.interview.repository.InterviewSessionDocumentRepository;
 import com.interviewai.backend.interview.repository.InterviewSessionRepository;
 import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.enums.OAuthProvider;
@@ -37,7 +41,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class InterviewServiceImplTest {
@@ -47,6 +54,9 @@ class InterviewServiceImplTest {
 
     @Mock
     private InterviewSessionRepository interviewSessionRepository;
+
+    @Mock
+    private InterviewSessionDocumentRepository interviewSessionDocumentRepository;
 
     @Mock
     private InterviewMessageRepository interviewMessageRepository;
@@ -114,6 +124,47 @@ class InterviewServiceImplTest {
         assertThat(response.getLevel()).isEqualTo(InterviewLevel.JUNIOR);
         assertThat(response.getFirstQuestion()).isNotBlank();
         verify(interviewSessionRepository).save(any(InterviewSession.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_이력서_모드에서_다중_문서로_면접_세션을_생성한다")
+    void 기능_테스트_이력서_모드에서_다중_문서로_면접_세션을_생성한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.RESUME);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L, 2L));
+
+        UserDocument resume = mock(UserDocument.class);
+        when(resume.getDocumentType()).thenReturn(DocumentType.RESUME);
+        when(resume.getParsedText()).thenReturn("이력서 내용입니다.");
+
+        UserDocument portfolio = mock(UserDocument.class);
+        when(portfolio.getDocumentType()).thenReturn(DocumentType.PORTFOLIO);
+        when(portfolio.getParsedText()).thenReturn("포트폴리오 내용입니다.");
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.RESUME)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L, 2L), userId))
+                .willReturn(List.of(resume, portfolio));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("면접을 시작하겠습니다.");
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+
+        // when
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getMode()).isEqualTo(InterviewMode.RESUME);
+        verify(interviewSessionDocumentRepository, times(2)).save(any(InterviewSessionDocument.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `InterviewStartRequestDto`: `documentId: Long` → `documentIds: List<Long>` 변경
- `InterviewSession`: `@ManyToOne document` 제거, `InterviewSessionDocument` 중간 엔티티 추가 (`interview_session_documents` 조인 테이블)
- `UserDocumentRepository`: `findAllByIdInAndUserId` 메서드 추가
- `InterviewServiceImpl`: 다중 문서 조회 → `InterviewSessionDocument` 저장 → 시스템 프롬프트에 타입별 라벨(이력서/포트폴리오/경력기술서)로 순회 출력
- `sendMessage`에서도 `InterviewSessionDocumentRepository`로 문서 목록 조회하도록 수정

## Test plan
- [ ] `./gradlew test` — 전체 테스트 통과
- [ ] `./gradlew build` — 빌드 성공
- [ ] RESUME/COMPANY 모드에서 문서 2개 이상 선택 후 면접 시작 정상 동작 확인
- [ ] 단일 문서 선택도 정상 동작 (기존 호환)
- [ ] BASIC 모드 (문서 없음) 정상 동작

Closes #16