### PR TITLE
refactor(#16): Anthropic → Gemini(OpenAI 호환) AI 프로바이더 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// Spring AI - Anthropic (Claude)
-	implementation 'org.springframework.ai:spring-ai-anthropic-spring-boot-starter'
+	// Spring AI - Anthropic (Claude) [주석 처리 - Gemini 전환]
+//	implementation 'org.springframework.ai:spring-ai-anthropic-spring-boot-starter'
+
+	// Spring AI - OpenAI 호환 (Gemini)
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 
 	// OAuth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/interviewai/backend/client/ClaudeAiClient.java
+++ b/src/main/java/com/interviewai/backend/client/ClaudeAiClient.java
@@ -2,11 +2,12 @@ package com.interviewai.backend.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.anthropic.AnthropicChatModel;
+// import org.springframework.ai.anthropic.AnthropicChatModel;  // [주석 처리 - Anthropic API]
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +19,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClaudeAiClient {
 
-    private final AnthropicChatModel chatModel;
+    // private final AnthropicChatModel chatModel;  // [주석 처리 - Anthropic API]
+    private final ChatModel chatModel;
 
     public String chat(String systemPrompt, List<com.interviewai.backend.client.dto.ChatMessage> history, String userMessage) {
         List<Message> messages = new ArrayList<>();

--- a/src/main/java/com/interviewai/backend/document/repository/UserDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/document/repository/UserDocumentRepository.java
@@ -15,4 +15,6 @@ public interface UserDocumentRepository extends JpaRepository<UserDocument, Long
     Page<UserDocument> findByUserId(Long userId, Pageable pageable);
 
     Optional<UserDocument> findByIdAndUserId(Long id, Long userId);
+
+    List<UserDocument> findAllByIdInAndUserId(List<Long> ids, Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class InterviewStartRequestDto {
@@ -18,7 +20,7 @@ public class InterviewStartRequestDto {
 
     private String jobTitle;
 
-    private Long documentId;
+    private List<Long> documentIds;
 
     private String jobPostingUrl;
 

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
@@ -1,6 +1,5 @@
 package com.interviewai.backend.interview.model;
 
-import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.InterviewMode;
 import com.interviewai.backend.interview.enums.InterviewStatus;
@@ -40,10 +39,6 @@ public class InterviewSession {
 
     private String jobTitle;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "document_id")
-    private UserDocument document;
-
     private String jobPostingUrl;
 
     @Column(columnDefinition = "TEXT")
@@ -59,14 +54,12 @@ public class InterviewSession {
 
     @Builder
     public InterviewSession(User user, InterviewMode mode, InterviewLevel level,
-                            String jobTitle, UserDocument document,
-                            String jobPostingUrl, String jobPostingContent) {
+                            String jobTitle, String jobPostingUrl, String jobPostingContent) {
         this.user = user;
         this.mode = mode;
         this.level = level;
         this.status = InterviewStatus.IN_PROGRESS;
         this.jobTitle = jobTitle;
-        this.document = document;
         this.jobPostingUrl = jobPostingUrl;
         this.jobPostingContent = jobPostingContent;
     }

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewSessionDocument.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewSessionDocument.java
@@ -1,0 +1,33 @@
+package com.interviewai.backend.interview.model;
+
+import com.interviewai.backend.document.model.UserDocument;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "interview_session_documents")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewSessionDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_session_id", nullable = false)
+    private InterviewSession session;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private UserDocument document;
+
+    @Builder
+    public InterviewSessionDocument(InterviewSession session, UserDocument document) {
+        this.session = session;
+        this.document = document;
+    }
+}

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
@@ -1,0 +1,11 @@
+package com.interviewai.backend.interview.repository;
+
+import com.interviewai.backend.interview.model.InterviewSessionDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterviewSessionDocumentRepository extends JpaRepository<InterviewSessionDocument, Long> {
+
+    List<InterviewSessionDocument> findBySessionId(Long sessionId);
+}

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -16,8 +16,10 @@ import com.interviewai.backend.interview.enums.MessageRole;
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.model.InterviewSessionDocument;
 import com.interviewai.backend.interview.repository.InterviewFeedbackRepository;
 import com.interviewai.backend.interview.repository.InterviewMessageRepository;
+import com.interviewai.backend.interview.repository.InterviewSessionDocumentRepository;
 import com.interviewai.backend.interview.repository.InterviewSessionRepository;
 import com.interviewai.backend.user.enums.UserErrorCode;
 import com.interviewai.backend.user.model.User;
@@ -29,6 +31,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -38,6 +41,7 @@ import java.util.List;
 public class InterviewServiceImpl implements InterviewService {
 
     private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewSessionDocumentRepository interviewSessionDocumentRepository;
     private final InterviewMessageRepository interviewMessageRepository;
     private final InterviewFeedbackRepository interviewFeedbackRepository;
     private final UserRepository userRepository;
@@ -54,10 +58,9 @@ public class InterviewServiceImpl implements InterviewService {
 
         validateModeRequirements(request);
 
-        UserDocument document = null;
-        if (request.getDocumentId() != null) {
-            document = userDocumentRepository.findByIdAndUserId(request.getDocumentId(), userId)
-                    .orElseThrow(() -> new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED));
+        List<UserDocument> documents = new ArrayList<>();
+        if (request.getDocumentIds() != null && !request.getDocumentIds().isEmpty()) {
+            documents = userDocumentRepository.findAllByIdInAndUserId(request.getDocumentIds(), userId);
         }
 
         String jobPostingContent = null;
@@ -75,13 +78,21 @@ public class InterviewServiceImpl implements InterviewService {
                 .mode(request.getMode())
                 .level(request.getLevel())
                 .jobTitle(request.getJobTitle())
-                .document(document)
                 .jobPostingUrl(request.getJobPostingUrl())
                 .jobPostingContent(jobPostingContent)
                 .build();
         session = interviewSessionRepository.save(session);
 
-        String systemPrompt = buildSystemPrompt(session, document, jobPostingContent, githubInfo);
+        for (UserDocument document : documents) {
+            interviewSessionDocumentRepository.save(
+                    InterviewSessionDocument.builder()
+                            .session(session)
+                            .document(document)
+                            .build()
+            );
+        }
+
+        String systemPrompt = buildSystemPrompt(session, documents, jobPostingContent, githubInfo);
         String firstQuestion = claudeAiClient.chat(systemPrompt, List.of(),
                 "면접을 시작해주세요. 첫 번째 질문을 해주세요.");
 
@@ -118,8 +129,11 @@ public class InterviewServiceImpl implements InterviewService {
                         msg.getContent()))
                 .toList();
 
-        UserDocument document = session.getDocument();
-        String systemPrompt = buildSystemPrompt(session, document, session.getJobPostingContent(), null);
+        List<UserDocument> documents = interviewSessionDocumentRepository.findBySessionId(sessionId)
+                .stream()
+                .map(InterviewSessionDocument::getDocument)
+                .toList();
+        String systemPrompt = buildSystemPrompt(session, documents, session.getJobPostingContent(), null);
         String aiResponse = claudeAiClient.chat(systemPrompt, history, request.getContent());
 
         interviewMessageRepository.save(InterviewMessage.builder()
@@ -225,17 +239,16 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     private void validateModeRequirements(InterviewStartRequestDto request) {
-        if (request.getMode() == InterviewMode.RESUME && request.getDocumentId() == null
-                && request.getGithubUrl() == null) {
+        boolean hasDocument = request.getDocumentIds() != null && !request.getDocumentIds().isEmpty();
+        if (request.getMode() == InterviewMode.RESUME && !hasDocument && request.getGithubUrl() == null) {
             throw new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED);
         }
-        if (request.getMode() == InterviewMode.COMPANY && request.getDocumentId() == null
-                && request.getGithubUrl() == null) {
+        if (request.getMode() == InterviewMode.COMPANY && !hasDocument && request.getGithubUrl() == null) {
             throw new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED);
         }
     }
 
-    private String buildSystemPrompt(InterviewSession session, UserDocument document,
+    private String buildSystemPrompt(InterviewSession session, List<UserDocument> documents,
                                      String jobPostingContent, String githubInfo) {
         StringBuilder prompt = new StringBuilder();
         String levelDescription = switch (session.getLevel()) {
@@ -259,11 +272,17 @@ public class InterviewServiceImpl implements InterviewService {
                 5. 면접 중에는 피드백이나 점수를 주지 않는다.
                 """);
 
-        if (document != null && document.getParsedText() != null) {
-            prompt.append("\n=== 지원자 이력서/포트폴리오 ===\n");
-            String parsedText = document.getParsedText();
-            if (parsedText.length() > 2000) {
-                parsedText = parsedText.substring(0, 2000) + "...";
+        for (UserDocument doc : documents) {
+            if (doc.getParsedText() == null) continue;
+            String docLabel = switch (doc.getDocumentType()) {
+                case RESUME -> "이력서";
+                case PORTFOLIO -> "포트폴리오";
+                case CAREER_STATEMENT -> "경력기술서";
+            };
+            prompt.append("\n=== 지원자 ").append(docLabel).append(" ===\n");
+            String parsedText = doc.getParsedText();
+            if (parsedText.length() > 1500) {
+                parsedText = parsedText.substring(0, 1500) + "...";
             }
             prompt.append(parsedText).append("\n");
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,11 +33,18 @@ spring:
             scope: email, profile
 
   ai:
-    anthropic:
-      api-key: ${ANTHROPIC_API_KEY}
+#    anthropic:                          # [주석 처리 - Anthropic API]
+#      api-key: ${ANTHROPIC_API_KEY}
+#      chat:
+#        options:
+#          model: claude-sonnet-4-6
+    openai:
+      api-key: ${GEMINI_API_KEY}
+      base-url: https://generativelanguage.googleapis.com/v1beta/openai
       chat:
+        completions-path: /chat/completions
         options:
-          model: claude-sonnet-4-6
+          model: gemini-2.0-flash
 
   servlet:
     multipart:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
       chat:
         completions-path: /chat/completions
         options:
-          model: gemini-2.0-flash
+          model: gemini-2.5-flash
 
   servlet:
     multipart:

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -4,14 +4,18 @@ import com.interviewai.backend.client.ClaudeAiClient;
 import com.interviewai.backend.client.GithubApiClient;
 import com.interviewai.backend.client.JobCrawlerClient;
 import com.interviewai.backend.common.exception.BusinessException;
+import com.interviewai.backend.document.enums.DocumentType;
+import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.document.repository.UserDocumentRepository;
 import com.interviewai.backend.interview.controller.dto.*;
 import com.interviewai.backend.interview.enums.*;
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.model.InterviewSessionDocument;
 import com.interviewai.backend.interview.repository.InterviewFeedbackRepository;
 import com.interviewai.backend.interview.repository.InterviewMessageRepository;
+import com.interviewai.backend.interview.repository.InterviewSessionDocumentRepository;
 import com.interviewai.backend.interview.repository.InterviewSessionRepository;
 import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.enums.OAuthProvider;
@@ -37,7 +41,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class InterviewServiceImplTest {
@@ -47,6 +54,9 @@ class InterviewServiceImplTest {
 
     @Mock
     private InterviewSessionRepository interviewSessionRepository;
+
+    @Mock
+    private InterviewSessionDocumentRepository interviewSessionDocumentRepository;
 
     @Mock
     private InterviewMessageRepository interviewMessageRepository;
@@ -114,6 +124,47 @@ class InterviewServiceImplTest {
         assertThat(response.getLevel()).isEqualTo(InterviewLevel.JUNIOR);
         assertThat(response.getFirstQuestion()).isNotBlank();
         verify(interviewSessionRepository).save(any(InterviewSession.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_이력서_모드에서_다중_문서로_면접_세션을_생성한다")
+    void 기능_테스트_이력서_모드에서_다중_문서로_면접_세션을_생성한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.RESUME);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L, 2L));
+
+        UserDocument resume = mock(UserDocument.class);
+        when(resume.getDocumentType()).thenReturn(DocumentType.RESUME);
+        when(resume.getParsedText()).thenReturn("이력서 내용입니다.");
+
+        UserDocument portfolio = mock(UserDocument.class);
+        when(portfolio.getDocumentType()).thenReturn(DocumentType.PORTFOLIO);
+        when(portfolio.getParsedText()).thenReturn("포트폴리오 내용입니다.");
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.RESUME)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L, 2L), userId))
+                .willReturn(List.of(resume, portfolio));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("면접을 시작하겠습니다.");
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+
+        // when
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getMode()).isEqualTo(InterviewMode.RESUME);
+        verify(interviewSessionDocumentRepository, times(2)).save(any(InterviewSessionDocument.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Anthropic API 크레딧 부족으로 인터뷰 시작 시 `NonTransientAiException` 발생하여 AI 프로바이더 전환
- `spring-ai-anthropic-spring-boot-starter` → `spring-ai-openai-spring-boot-starter` (Gemini OpenAI 호환 엔드포인트)
- 기존 Anthropic 코드는 삭제하지 않고 주석 처리하여 추후 복원 가능하도록 유지
- 모델: `gemini-2.5-flash` (2.0 시리즈는 신규 계정 차단됨)

## 변경 파일

- `build.gradle` — anthropic 의존성 → openai 의존성으로 전환
- `application.yml` — Anthropic 설정 주석 처리, Gemini OpenAI 호환 설정 추가
- `ClaudeAiClient.java` — `AnthropicChatModel` → `ChatModel` 추상 인터페이스로 변경

## Test plan

- [x] `./gradlew test` 통과 확인 (ClaudeAiClient는 mock 처리이므로 영향 없음)
- [x] `./gradlew build` 빌드 성공 확인
- [x] 앱 실행 후 인터뷰 시작 → Gemini 응답 정상 수신 확인