### PR TITLE
feat(#19): 인터뷰 충분성 감지 및 종료 제안 UI 구현 (Backend)

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewSendMessageResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewSendMessageResponseDto.java
@@ -9,4 +9,5 @@ public class InterviewSendMessageResponseDto {
 
     private String aiResponse;
     private boolean isCompleted;
+    private boolean suggestFinish;
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -133,18 +133,21 @@ public class InterviewServiceImpl implements InterviewService {
                 .stream()
                 .map(InterviewSessionDocument::getDocument)
                 .toList();
-        String systemPrompt = buildSystemPrompt(session, documents, session.getJobPostingContent(), null);
-        String aiResponse = claudeAiClient.chat(systemPrompt, history, request.getContent());
+        String systemPrompt = buildSendMessageSystemPrompt(session, documents, session.getJobPostingContent());
+        String rawResponse = claudeAiClient.chat(systemPrompt, history, request.getContent());
+
+        AiStructuredResponse parsed = parseAiStructuredResponse(rawResponse);
 
         interviewMessageRepository.save(InterviewMessage.builder()
                 .session(session)
                 .role(MessageRole.AI)
-                .content(aiResponse)
+                .content(parsed.nextQuestion())
                 .build());
 
         return InterviewSendMessageResponseDto.builder()
-                .aiResponse(aiResponse)
+                .aiResponse(parsed.nextQuestion())
                 .isCompleted(false)
+                .suggestFinish(parsed.suggestFinish())
                 .build();
     }
 
@@ -302,6 +305,47 @@ public class InterviewServiceImpl implements InterviewService {
         }
 
         return prompt.toString();
+    }
+
+    private String buildSendMessageSystemPrompt(InterviewSession session, List<UserDocument> documents,
+                                                 String jobPostingContent) {
+        String base = buildSystemPrompt(session, documents, jobPostingContent, null);
+        String finishCriteria = session.getLevel() == InterviewLevel.JUNIOR
+                ? "- JUNIOR: 최소 5개 이상의 질문을 통해 기술 이해도, 문제 해결, 커뮤니케이션, 경험/사례 영역을 고루 다뤘을 때"
+                : "- SENIOR: 최소 7개 이상의 질문을 통해 기술 이해도, 문제 해결, 커뮤니케이션, 경험/사례 영역에 더해 기술 깊이/아키텍처, 리더십/협업 영역까지 다뤘을 때";
+
+        return base + """
+
+                응답 형식 (반드시 아래 JSON만 반환, 다른 텍스트 없이):
+                {
+                  "nextQuestion": "다음 면접 질문 내용",
+                  "suggestFinish": false
+                }
+
+                suggestFinish를 true로 설정하는 기준:
+                """ + finishCriteria;
+    }
+
+    private record AiStructuredResponse(String nextQuestion, boolean suggestFinish) {
+    }
+
+    private AiStructuredResponse parseAiStructuredResponse(String rawResponse) {
+        try {
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            String jsonStr = rawResponse;
+            int jsonStart = jsonStr.indexOf('{');
+            int jsonEnd = jsonStr.lastIndexOf('}');
+            if (jsonStart >= 0 && jsonEnd >= 0) {
+                jsonStr = jsonStr.substring(jsonStart, jsonEnd + 1);
+                com.fasterxml.jackson.databind.JsonNode node = mapper.readTree(jsonStr);
+                String nextQuestion = node.has("nextQuestion") ? node.get("nextQuestion").asText() : rawResponse;
+                boolean suggestFinish = node.has("suggestFinish") && node.get("suggestFinish").asBoolean(false);
+                return new AiStructuredResponse(nextQuestion, suggestFinish);
+            }
+        } catch (Exception e) {
+            log.warn("AI 구조화 응답 파싱 실패, 원본 텍스트 사용: {}", e.getMessage());
+        }
+        return new AiStructuredResponse(rawResponse, false);
     }
 
     private String buildFeedbackSystemPrompt(InterviewSession session) {

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -439,6 +439,99 @@ class InterviewServiceImplTest {
         assertThat(result.getAverageScore()).isNull();
     }
 
+    @Test
+    @DisplayName("기능_테스트_메시지_전송_시_suggestFinish_가_false_로_반환된다")
+    void 기능_테스트_메시지_전송_시_suggestFinish_가_false_로_반환된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "Java는 객체지향 언어입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        String structuredResponse = "{\"nextQuestion\": \"다음 질문입니다.\", \"suggestFinish\": false}";
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any())).willReturn(structuredResponse);
+
+        // when
+        InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        assertThat(response.getAiResponse()).isEqualTo("다음 질문입니다.");
+        assertThat(response.isSuggestFinish()).isFalse();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_AI가_충분성_신호를_보내면_suggestFinish_가_true_로_반환된다")
+    void 기능_테스트_AI가_충분성_신호를_보내면_suggestFinish_가_true_로_반환된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "마지막 답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        String structuredResponse = "{\"nextQuestion\": \"수고하셨습니다. 추가로 하실 말씀이 있으신가요?\", \"suggestFinish\": true}";
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any())).willReturn(structuredResponse);
+
+        // when
+        InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다. 추가로 하실 말씀이 있으신가요?");
+        assertThat(response.isSuggestFinish()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_AI_응답_파싱_실패시_원본_텍스트를_nextQuestion으로_사용한다")
+    void 기능_테스트_AI_응답_파싱_실패시_원본_텍스트를_nextQuestion으로_사용한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        String plainTextResponse = "JSON이 아닌 일반 텍스트 응답입니다.";
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any())).willReturn(plainTextResponse);
+
+        // when
+        InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        assertThat(response.getAiResponse()).isEqualTo(plainTextResponse);
+        assertThat(response.isSuggestFinish()).isFalse();
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## Summary

- `InterviewSendMessageResponseDto`에 `suggestFinish` 필드 추가
- AI가 JUNIOR 5개+, SENIOR 7개+ 핵심 영역을 커버하면 `suggestFinish: true` 반환
- `InterviewServiceImpl`에 구조화 JSON 응답 파싱 로직 추가 (`parseAiStructuredResponse`)
- AI가 JSON 외 텍스트 반환 시 원본 텍스트를 `nextQuestion`으로 사용하는 graceful fallback 처리

## 변경 파일

- `InterviewSendMessageResponseDto.java` — `suggestFinish` 필드 추가
- `InterviewServiceImpl.java` — `buildSendMessageSystemPrompt()`, `parseAiStructuredResponse()` 추가 및 `sendMessage()` 흐름 변경
- `InterviewServiceImplTest.java` — suggestFinish 관련 테스트 3개 추가

## Test plan

- [x] `./gradlew test` — 전체 테스트 통과
- [x] `./gradlew build` — 빌드 성공

Closes #19