### PR TITLE
feat(#23): 인터뷰 삭제 기능 구현

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
@@ -83,6 +83,15 @@ public class InterviewController {
         return ResponseEntity.ok(ApiResponse.ok(null, "면접이 취소되었습니다."));
     }
 
+    @Operation(summary = "면접 삭제")
+    @DeleteMapping("/{sessionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteInterview(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId) {
+        interviewService.deleteInterview(userId, sessionId);
+        return ResponseEntity.ok(ApiResponse.ok(null, "면접이 삭제되었습니다."));
+    }
+
     @Operation(summary = "내 면접 통계 조회")
     @GetMapping("/stats")
     public ResponseEntity<ApiResponse<InterviewStatsResponseDto>> getMyStats(

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
@@ -12,4 +12,6 @@ public interface InterviewFeedbackRepository extends JpaRepository<InterviewFeed
 
     @Query("SELECT AVG(f.overallScore) FROM InterviewFeedback f WHERE f.session.user.id = :userId")
     Double findAverageScoreByUserId(Long userId);
+
+    void deleteBySessionId(Long sessionId);
 }

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewMessageRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewMessageRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface InterviewMessageRepository extends JpaRepository<InterviewMessage, Long> {
 
     List<InterviewMessage> findBySessionIdOrderByCreatedAtAsc(Long sessionId);
+
+    void deleteBySessionId(Long sessionId);
 }

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface InterviewSessionDocumentRepository extends JpaRepository<InterviewSessionDocument, Long> {
 
     List<InterviewSessionDocument> findBySessionId(Long sessionId);
+
+    void deleteBySessionId(Long sessionId);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
@@ -22,5 +22,7 @@ public interface InterviewService {
 
     void cancelInterview(Long userId, Long sessionId);
 
+    void deleteInterview(Long userId, Long sessionId);
+
     InterviewStatsResponseDto getMyStats(Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -187,6 +187,18 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
+    @Transactional
+    public void deleteInterview(Long userId, Long sessionId) {
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(InterviewErrorCode.SESSION_NOT_FOUND));
+
+        interviewMessageRepository.deleteBySessionId(sessionId);
+        interviewSessionDocumentRepository.deleteBySessionId(sessionId);
+        interviewFeedbackRepository.deleteBySessionId(sessionId);
+        interviewSessionRepository.delete(session);
+    }
+
+    @Override
     public Page<InterviewSessionResponseDto> findMySessions(Long userId, Pageable pageable) {
         return interviewSessionRepository.findByUserId(userId, pageable)
                 .map(InterviewSessionResponseDto::from);

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -381,6 +381,102 @@ class InterviewServiceImplTest {
     }
 
     @Test
+    @DisplayName("기능_테스트_진행_중인_면접_세션을_삭제한다")
+    void 기능_테스트_진행_중인_면접_세션을_삭제한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+
+        // when
+        interviewService.deleteInterview(userId, sessionId);
+
+        // then
+        verify(interviewMessageRepository).deleteBySessionId(sessionId);
+        verify(interviewSessionDocumentRepository).deleteBySessionId(sessionId);
+        verify(interviewFeedbackRepository).deleteBySessionId(sessionId);
+        verify(interviewSessionRepository).delete(session);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_완료된_면접_세션을_삭제한다")
+    void 기능_테스트_완료된_면접_세션을_삭제한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        session.complete();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+
+        // when
+        interviewService.deleteInterview(userId, sessionId);
+
+        // then
+        verify(interviewMessageRepository).deleteBySessionId(sessionId);
+        verify(interviewSessionDocumentRepository).deleteBySessionId(sessionId);
+        verify(interviewFeedbackRepository).deleteBySessionId(sessionId);
+        verify(interviewSessionRepository).delete(session);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_취소된_면접_세션을_삭제한다")
+    void 기능_테스트_취소된_면접_세션을_삭제한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        session.cancel();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+
+        // when
+        interviewService.deleteInterview(userId, sessionId);
+
+        // then
+        verify(interviewMessageRepository).deleteBySessionId(sessionId);
+        verify(interviewSessionDocumentRepository).deleteBySessionId(sessionId);
+        verify(interviewFeedbackRepository).deleteBySessionId(sessionId);
+        verify(interviewSessionRepository).delete(session);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_세션을_삭제하면_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_세션을_삭제하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.deleteInterview(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
+    @Test
     @DisplayName("기능_테스트_인터뷰_통계를_조회한다")
     void 기능_테스트_인터뷰_통계를_조회한다() {
         // given


### PR DESCRIPTION
## Summary
- 인터뷰 기록에서 인터뷰를 삭제할 수 있는 `DELETE /api/interviews/{sessionId}` 엔드포인트 추가
- 상태(IN_PROGRESS / COMPLETED / CANCELLED)에 관계없이 삭제 가능
- 삭제 시 InterviewMessage → InterviewSessionDocument → InterviewFeedback → InterviewSession 순으로 연관 데이터 삭제
- 본인 소유 세션만 삭제 가능 (타인 세션 접근 시 SESSION_NOT_FOUND)

## Test plan
- [x] `./gradlew test` 통과 확인
- [x] `./gradlew build` 빌드 성공 확인
- [x] IN_PROGRESS / COMPLETED / CANCELLED 세 가지 상태 모두 삭제 가능한지 확인
- [x] 존재하지 않는 세션 삭제 시 예외 발생 확인

Closes #23