### PR TITLE
feat(#25): 면접 다중 삭제 API 구현

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
@@ -92,6 +92,15 @@ public class InterviewController {
         return ResponseEntity.ok(ApiResponse.ok(null, "면접이 삭제되었습니다."));
     }
 
+    @Operation(summary = "면접 다중 삭제")
+    @PostMapping("/batch-delete")
+    public ResponseEntity<ApiResponse<Void>> deleteInterviews(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody InterviewBatchDeleteRequestDto request) {
+        interviewService.deleteInterviews(userId, request.getSessionIds());
+        return ResponseEntity.ok(ApiResponse.ok(null, "선택한 면접이 삭제되었습니다."));
+    }
+
     @Operation(summary = "내 면접 통계 조회")
     @GetMapping("/stats")
     public ResponseEntity<ApiResponse<InterviewStatsResponseDto>> getMyStats(

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewBatchDeleteRequestDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewBatchDeleteRequestDto.java
@@ -1,0 +1,19 @@
+package com.interviewai.backend.interview.controller.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class InterviewBatchDeleteRequestDto {
+
+    @NotNull
+    @NotEmpty(message = "삭제할 면접을 선택해 주세요.")
+    @Size(max = 50, message = "한 번에 최대 50개까지 삭제할 수 있습니다.")
+    private List<@NotNull Long> sessionIds;
+}

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
@@ -4,6 +4,7 @@ import com.interviewai.backend.interview.model.InterviewFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InterviewFeedbackRepository extends JpaRepository<InterviewFeedback, Long> {

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
@@ -14,4 +14,6 @@ public interface InterviewFeedbackRepository extends JpaRepository<InterviewFeed
     Double findAverageScoreByUserId(Long userId);
 
     void deleteBySessionId(Long sessionId);
+
+    void deleteAllBySessionIdIn(List<Long> sessionIds);
 }

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewMessageRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewMessageRepository.java
@@ -10,4 +10,6 @@ public interface InterviewMessageRepository extends JpaRepository<InterviewMessa
     List<InterviewMessage> findBySessionIdOrderByCreatedAtAsc(Long sessionId);
 
     void deleteBySessionId(Long sessionId);
+
+    void deleteAllBySessionIdIn(List<Long> sessionIds);
 }

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionDocumentRepository.java
@@ -10,4 +10,6 @@ public interface InterviewSessionDocumentRepository extends JpaRepository<Interv
     List<InterviewSessionDocument> findBySessionId(Long sessionId);
 
     void deleteBySessionId(Long sessionId);
+
+    void deleteAllBySessionIdIn(List<Long> sessionIds);
 }

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewSessionRepository.java
@@ -15,6 +15,8 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
 
     List<InterviewSession> findByUserIdOrderByCreatedAtDesc(Long userId);
 
+    List<InterviewSession> findAllByIdInAndUserId(List<Long> ids, Long userId);
+
     Page<InterviewSession> findByUserId(Long userId, Pageable pageable);
 
     Optional<InterviewSession> findByIdAndUserId(Long id, Long userId);

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
@@ -24,5 +24,7 @@ public interface InterviewService {
 
     void deleteInterview(Long userId, Long sessionId);
 
+    void deleteInterviews(Long userId, List<Long> sessionIds);
+
     InterviewStatsResponseDto getMyStats(Long userId);
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -199,6 +199,22 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Override
+    @Transactional
+    public void deleteInterviews(Long userId, List<Long> sessionIds) {
+        List<Long> uniqueIds = sessionIds.stream().distinct().toList();
+
+        List<InterviewSession> sessions = interviewSessionRepository.findAllByIdInAndUserId(uniqueIds, userId);
+        if (sessions.size() != uniqueIds.size()) {
+            throw new BusinessException(InterviewErrorCode.SESSION_NOT_FOUND);
+        }
+
+        interviewMessageRepository.deleteAllBySessionIdIn(uniqueIds);
+        interviewSessionDocumentRepository.deleteAllBySessionIdIn(uniqueIds);
+        interviewFeedbackRepository.deleteAllBySessionIdIn(uniqueIds);
+        interviewSessionRepository.deleteAll(sessions);
+    }
+
+    @Override
     public Page<InterviewSessionResponseDto> findMySessions(Long userId, Pageable pageable) {
         return interviewSessionRepository.findByUserId(userId, pageable)
                 .map(InterviewSessionResponseDto::from);

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -628,6 +628,97 @@ class InterviewServiceImplTest {
         assertThat(response.isSuggestFinish()).isFalse();
     }
 
+    @Test
+    @DisplayName("기능_테스트_여러_면접_세션을_일괄_삭제한다")
+    void 기능_테스트_여러_면접_세션을_일괄_삭제한다() {
+        // given
+        Long userId = 1L;
+        List<Long> sessionIds = List.of(1L, 2L, 3L);
+
+        InterviewSession session1 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+        InterviewSession session2 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.SENIOR).build();
+        InterviewSession session3 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.RESUME).level(InterviewLevel.JUNIOR).build();
+        List<InterviewSession> sessions = List.of(session1, session2, session3);
+
+        given(interviewSessionRepository.findAllByIdInAndUserId(sessionIds, userId)).willReturn(sessions);
+
+        // when
+        interviewService.deleteInterviews(userId, sessionIds);
+
+        // then
+        verify(interviewMessageRepository).deleteAllBySessionIdIn(sessionIds);
+        verify(interviewSessionDocumentRepository).deleteAllBySessionIdIn(sessionIds);
+        verify(interviewFeedbackRepository).deleteAllBySessionIdIn(sessionIds);
+        verify(interviewSessionRepository).deleteAll(sessions);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_중복된_ID가_포함되어도_정상_삭제된다")
+    void 기능_테스트_중복된_ID가_포함되어도_정상_삭제된다() {
+        // given
+        Long userId = 1L;
+        List<Long> sessionIdsWithDuplicate = List.of(1L, 2L, 1L);
+        List<Long> uniqueIds = List.of(1L, 2L);
+
+        InterviewSession session1 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+        InterviewSession session2 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.SENIOR).build();
+        List<InterviewSession> sessions = List.of(session1, session2);
+
+        given(interviewSessionRepository.findAllByIdInAndUserId(uniqueIds, userId)).willReturn(sessions);
+
+        // when
+        interviewService.deleteInterviews(userId, sessionIdsWithDuplicate);
+
+        // then
+        verify(interviewMessageRepository).deleteAllBySessionIdIn(uniqueIds);
+        verify(interviewSessionDocumentRepository).deleteAllBySessionIdIn(uniqueIds);
+        verify(interviewFeedbackRepository).deleteAllBySessionIdIn(uniqueIds);
+        verify(interviewSessionRepository).deleteAll(sessions);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_다른_사용자의_세션이_포함되면_예외가_발생한다")
+    void 예외_테스트_다른_사용자의_세션이_포함되면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        List<Long> sessionIds = List.of(1L, 2L, 3L);
+
+        InterviewSession session1 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(interviewSessionRepository.findAllByIdInAndUserId(sessionIds, userId))
+                .willReturn(List.of(session1));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.deleteInterviews(userId, sessionIds))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_세션이_포함되면_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_세션이_포함되면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        List<Long> sessionIds = List.of(1L, 999L);
+
+        InterviewSession session1 = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(interviewSessionRepository.findAllByIdInAndUserId(sessionIds, userId))
+                .willReturn(List.of(session1));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.deleteInterviews(userId, sessionIds))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## Summary
- `POST /api/interviews/batch-delete` 엔드포인트 추가
- 배치 쿼리로 N+1 제거 (`findAllByIdInAndUserId`, `deleteAllBySessionIdIn`)
- 최대 50개 제한, 중복 ID 자동 제거, 전체 트랜잭션 보장

## Test plan
- [x] `기능_테스트_여러_면접_세션을_일괄_삭제한다`
- [x] `기능_테스트_중복된_ID가_포함되어도_정상_삭제된다`
- [x] `예외_테스트_다른_사용자의_세션이_포함되면_예외가_발생한다`
- [x] `예외_테스트_존재하지_않는_세션이_포함되면_예외가_발생한다`

Closes #25