### PR TITLE
chore(#31): Jacoco 설정 및 SonarQube 커버리지 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -74,6 +75,29 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+	}
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+				'**/config/**',
+				'**/security/**',
+				'**/*Application*',
+				'**/dto/**',
+				'**/model/**',
+				'**/enums/**',
+				'**/exception/**',
+				'**/client/**',
+			])
+		}))
+	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml

--- a/src/test/java/com/interviewai/backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/user/service/UserServiceImplTest.java
@@ -1,0 +1,70 @@
+package com.interviewai.backend.user.service;
+
+import com.interviewai.backend.common.exception.BusinessException;
+import com.interviewai.backend.user.controller.dto.UserProfileResponseDto;
+import com.interviewai.backend.user.enums.OAuthProvider;
+import com.interviewai.backend.user.enums.UserErrorCode;
+import com.interviewai.backend.user.enums.UserRole;
+import com.interviewai.backend.user.model.User;
+import com.interviewai.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("기능_테스트_유저_프로필_조회에_성공한다")
+    void 기능_테스트_유저_프로필_조회에_성공한다() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("test@test.com")
+                .name("테스트유저")
+                .profileImageUrl("https://example.com/image.png")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        UserProfileResponseDto result = userService.findUserProfile(userId);
+
+        // then
+        assertThat(result.getEmail()).isEqualTo("test@test.com");
+        assertThat(result.getName()).isEqualTo("테스트유저");
+        assertThat(result.getProvider()).isEqualTo(OAuthProvider.GITHUB);
+        assertThat(result.getRole()).isEqualTo(UserRole.USER);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_유저가_존재하지_않으면_USER_NOT_FOUND_예외가_발생한다")
+    void 예외_테스트_유저가_존재하지_않으면_USER_NOT_FOUND_예외가_발생한다() {
+        // given
+        Long nonExistentUserId = 999L;
+        given(userRepository.findById(nonExistentUserId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.findUserProfile(nonExistentUserId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- `build.gradle`에 Jacoco 플러그인 추가 및 `jacocoTestReport` 태스크 구성 (XML 리포트 자동 생성)
- `sonar-project.properties` 생성 — SonarCloud에 XML 커버리지 경로 지정
- `UserServiceImplTest` 추가 — 누락된 유저 서비스 레이어 테스트 보완 (성공/USER_NOT_FOUND 예외)

## Test plan
- [x] `./gradlew test` 전체 통과
- [x] `build/reports/jacoco/test/jacocoTestReport.xml` 생성 확인
- [x] `./gradlew build` 성공

Closes #31