### PR TITLE
chore(#33): SonarCloud CI 분석 파이프라인 구축

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,36 @@
+name: SonarQube
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu'
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "org.sonarqube" version "7.2.3.7755"
 }
 
 group = 'com.interviewai'
@@ -78,6 +79,14 @@ dependencies {
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
+}
+
+sonar {
+	properties {
+		property "sonar.projectKey", "handokei_interviewAI"
+		property "sonar.organization", "handokei"
+		property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
+	}
 }
 
 jacocoTestReport {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: test-github-client-id
+            client-secret: test-github-client-secret
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+  ai:
+    openai:
+      api-key: test-api-key
+      base-url: http://localhost
+
+jwt:
+  secret: test-jwt-secret-for-ci-minimum-256bit-length-required-padding-here


### PR DESCRIPTION
## Summary
- `org.sonarqube` Gradle 플러그인 추가 및 프로젝트 키/조직 설정 (build.gradle)
- `.github/workflows/sonarcloud.yml` 생성 — PR/push 시 테스트 → Jacoco → SonarCloud 분석 자동 실행
- `sonar-project.properties` 제거 — build.gradle sonar 블록으로 통합

## Test plan
- [x] `./gradlew test` 전체 통과
- [x] `./gradlew build` 성공
- [x] SonarCloud Automatic Analysis OFF 확인
- [x] `SONAR_TOKEN` GitHub Secret 등록 확인

Closes #33