### PR TITLE
fix(#36): suggestFinish 임계값 수정 및 스트리밍 doOnComplete 오류 방어 처리

### DIFF
--- a/src/main/java/com/interviewai/backend/client/ClaudeAiClient.java
+++ b/src/main/java/com/interviewai/backend/client/ClaudeAiClient.java
@@ -8,8 +8,10 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +41,28 @@ public class ClaudeAiClient {
         String response = chatModel.call(prompt).getResult().getOutput().getText();
         log.info("Claude response received, length: {}", response != null ? response.length() : 0);
         return response;
+    }
+
+    public Flux<String> streamChat(String systemPrompt,
+                                   List<com.interviewai.backend.client.dto.ChatMessage> history,
+                                   String userMessage) {
+        List<Message> messages = new ArrayList<>();
+        messages.add(new SystemMessage(systemPrompt));
+
+        for (com.interviewai.backend.client.dto.ChatMessage msg : history) {
+            if ("user".equals(msg.role())) {
+                messages.add(new UserMessage(msg.content()));
+            } else {
+                messages.add(new AssistantMessage(msg.content()));
+            }
+        }
+        messages.add(new UserMessage(userMessage));
+
+        Prompt prompt = new Prompt(messages);
+        return ((StreamingChatModel) chatModel)
+                .stream(prompt)
+                .mapNotNull(res -> res.getResult().getOutput().getText())
+                .filter(text -> text != null && !text.isEmpty());
     }
 
     public String generateFeedback(String systemPrompt, String conversationText) {

--- a/src/main/java/com/interviewai/backend/config/SecurityConfig.java
+++ b/src/main/java/com/interviewai/backend/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import jakarta.servlet.DispatcherType;
 import java.util.List;
 
 @Configuration
@@ -36,6 +37,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers("/api/auth/**", "/oauth2/**", "/login/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()

--- a/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/InterviewController.java
@@ -11,9 +11,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -40,6 +42,15 @@ public class InterviewController {
             @PathVariable Long sessionId,
             @Valid @RequestBody InterviewSendMessageRequestDto request) {
         return ResponseEntity.ok(ApiResponse.ok(interviewService.sendMessage(userId, sessionId, request)));
+    }
+
+    @Operation(summary = "메시지 전송 (답변) — 스트리밍")
+    @PostMapping(value = "/{sessionId}/messages/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamMessage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody InterviewSendMessageRequestDto request) {
+        return interviewService.streamMessage(userId, sessionId, request);
     }
 
     @Operation(summary = "면접 종료 및 피드백 생성")

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
@@ -37,8 +37,10 @@ public class InterviewSession {
     @Column(nullable = false)
     private InterviewStatus status;
 
+    @Column(columnDefinition = "TEXT")
     private String jobTitle;
 
+    @Column(columnDefinition = "TEXT")
     private String jobPostingUrl;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
@@ -9,6 +9,7 @@ import com.interviewai.backend.interview.repository.InterviewSessionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -23,7 +24,7 @@ public class InterviewMessageSaver {
     private final InterviewSessionRepository interviewSessionRepository;
     private final InterviewMessageRepository interviewMessageRepository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveUserMessage(Long sessionId, String content) {
         InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
         interviewMessageRepository.save(InterviewMessage.builder()
@@ -33,7 +34,7 @@ public class InterviewMessageSaver {
                 .build());
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveAiMessageAndComplete(SseEmitter emitter, Long sessionId,
                                          InterviewLevel level, String aiContent) {
         InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
@@ -1,0 +1,64 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.interview.enums.InterviewLevel;
+import com.interviewai.backend.interview.enums.MessageRole;
+import com.interviewai.backend.interview.model.InterviewMessage;
+import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.repository.InterviewMessageRepository;
+import com.interviewai.backend.interview.repository.InterviewSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterviewMessageSaver {
+
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewMessageRepository interviewMessageRepository;
+
+    @Transactional
+    public void saveUserMessage(Long sessionId, String content) {
+        InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
+        interviewMessageRepository.save(InterviewMessage.builder()
+                .session(sessionRef)
+                .role(MessageRole.USER)
+                .content(content)
+                .build());
+    }
+
+    @Transactional
+    public void saveAiMessageAndComplete(SseEmitter emitter, Long sessionId,
+                                         InterviewLevel level, String aiContent) {
+        InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
+        interviewMessageRepository.save(InterviewMessage.builder()
+                .session(sessionRef)
+                .role(MessageRole.AI)
+                .content(aiContent)
+                .build());
+
+        List<InterviewMessage> allMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        long aiMessageCount = allMessages.stream()
+                .filter(m -> m.getRole() == MessageRole.AI)
+                .count();
+        boolean suggestFinish = switch (level) {
+            case JUNIOR -> aiMessageCount >= 5;
+            case SENIOR -> aiMessageCount >= 7;
+        };
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("done")
+                    .data("{\"suggestFinish\":" + suggestFinish + "}"));
+            emitter.complete();
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+    }
+}

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
@@ -49,8 +49,8 @@ public class InterviewMessageSaver {
                 .filter(m -> m.getRole() == MessageRole.AI)
                 .count();
         boolean suggestFinish = switch (level) {
-            case JUNIOR -> aiMessageCount >= 5;
-            case SENIOR -> aiMessageCount >= 7;
+            case JUNIOR -> aiMessageCount >= 6;
+            case SENIOR -> aiMessageCount >= 8;
         };
 
         try {

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewService.java
@@ -3,6 +3,7 @@ package com.interviewai.backend.interview.service;
 import com.interviewai.backend.interview.controller.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -11,6 +12,8 @@ public interface InterviewService {
     InterviewStartResponseDto startInterview(Long userId, InterviewStartRequestDto request);
 
     InterviewSendMessageResponseDto sendMessage(Long userId, Long sessionId, InterviewSendMessageRequestDto request);
+
+    SseEmitter streamMessage(Long userId, Long sessionId, InterviewSendMessageRequestDto request);
 
     InterviewFeedbackResponseDto finishInterview(Long userId, Long sessionId);
 

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -195,25 +195,14 @@ public class InterviewServiceImpl implements InterviewService {
                 claudeAiClient.streamChat(systemPrompt, history, request.getContent())
                         .doOnNext(token -> {
                             aiContent.append(token);
-                            try {
-                                emitter.send(SseEmitter.event().data(token));
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
+                            sendTokenToEmitter(emitter, token);
                         })
                         .doOnComplete(() -> {
                             try {
                                 interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
                             } catch (Exception e) {
                                 log.error("AI 메시지 저장 실패, emitter 강제 종료", e);
-                                try {
-                                    emitter.send(SseEmitter.event()
-                                            .name("done")
-                                            .data("{\"suggestFinish\":false}"));
-                                    emitter.complete();
-                                } catch (IOException ioEx) {
-                                    emitter.completeWithError(ioEx);
-                                }
+                                emitter.completeWithError(e);
                             }
                         })
                         .doOnError(e -> emitter.completeWithError(e))
@@ -447,6 +436,14 @@ public class InterviewServiceImpl implements InterviewService {
             sb.append(message.getContent()).append("\n\n");
         }
         return sb.toString();
+    }
+
+    void sendTokenToEmitter(SseEmitter emitter, String token) {
+        try {
+            emitter.send(SseEmitter.event().data(token));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private InterviewFeedback parseFeedbackAndSave(InterviewSession session, String feedbackJson) {

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -53,6 +53,7 @@ public class InterviewServiceImpl implements InterviewService {
     private final ClaudeAiClient claudeAiClient;
     private final GithubApiClient githubApiClient;
     private final JobCrawlerClient jobCrawlerClient;
+    private final InterviewMessageSaver interviewMessageSaver;
 
     @Override
     @Transactional
@@ -171,7 +172,7 @@ public class InterviewServiceImpl implements InterviewService {
             throw new BusinessException(InterviewErrorCode.SESSION_ALREADY_COMPLETED);
         }
 
-        saveUserMessage(sessionId, request.getContent());
+        interviewMessageSaver.saveUserMessage(sessionId, request.getContent());
 
         List<InterviewMessage> messages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
         List<ChatMessage> history = messages.stream()
@@ -201,7 +202,7 @@ public class InterviewServiceImpl implements InterviewService {
                             }
                         })
                         .doOnComplete(() -> {
-                            saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
+                            interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
                         })
                         .doOnError(e -> emitter.completeWithError(e))
                         .subscribe();
@@ -211,45 +212,6 @@ public class InterviewServiceImpl implements InterviewService {
         });
         executor.shutdown();
         return emitter;
-    }
-
-    @Transactional
-    public void saveUserMessage(Long sessionId, String content) {
-        InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
-        interviewMessageRepository.save(InterviewMessage.builder()
-                .session(sessionRef)
-                .role(MessageRole.USER)
-                .content(content)
-                .build());
-    }
-
-    @Transactional
-    public void saveAiMessageAndComplete(SseEmitter emitter, Long sessionId,
-                                         InterviewLevel level, String aiContent) {
-        InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
-        interviewMessageRepository.save(InterviewMessage.builder()
-                .session(sessionRef)
-                .role(MessageRole.AI)
-                .content(aiContent)
-                .build());
-
-        List<InterviewMessage> allMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
-        long aiMessageCount = allMessages.stream()
-                .filter(m -> m.getRole() == MessageRole.AI)
-                .count();
-        boolean suggestFinish = switch (level) {
-            case JUNIOR -> aiMessageCount >= 5;
-            case SENIOR -> aiMessageCount >= 7;
-        };
-
-        try {
-            emitter.send(SseEmitter.event()
-                    .name("done")
-                    .data("{\"suggestFinish\":" + suggestFinish + "}"));
-            emitter.complete();
-        } catch (IOException e) {
-            emitter.completeWithError(e);
-        }
     }
 
     @Override

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -171,7 +171,7 @@ public class InterviewServiceImpl implements InterviewService {
             throw new BusinessException(InterviewErrorCode.SESSION_ALREADY_COMPLETED);
         }
 
-        saveUserMessage(session, request.getContent());
+        saveUserMessage(sessionId, request.getContent());
 
         List<InterviewMessage> messages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
         List<ChatMessage> history = messages.stream()
@@ -201,7 +201,7 @@ public class InterviewServiceImpl implements InterviewService {
                             }
                         })
                         .doOnComplete(() -> {
-                            saveAiMessageAndComplete(emitter, session, sessionId, aiContent.toString());
+                            saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
                         })
                         .doOnError(e -> emitter.completeWithError(e))
                         .subscribe();
@@ -214,19 +214,21 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     @Transactional
-    public void saveUserMessage(InterviewSession session, String content) {
+    public void saveUserMessage(Long sessionId, String content) {
+        InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
         interviewMessageRepository.save(InterviewMessage.builder()
-                .session(session)
+                .session(sessionRef)
                 .role(MessageRole.USER)
                 .content(content)
                 .build());
     }
 
     @Transactional
-    public void saveAiMessageAndComplete(SseEmitter emitter, InterviewSession session,
-                                         Long sessionId, String aiContent) {
+    public void saveAiMessageAndComplete(SseEmitter emitter, Long sessionId,
+                                         InterviewLevel level, String aiContent) {
+        InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
         interviewMessageRepository.save(InterviewMessage.builder()
-                .session(session)
+                .session(sessionRef)
                 .role(MessageRole.AI)
                 .content(aiContent)
                 .build());
@@ -235,7 +237,7 @@ public class InterviewServiceImpl implements InterviewService {
         long aiMessageCount = allMessages.stream()
                 .filter(m -> m.getRole() == MessageRole.AI)
                 .count();
-        boolean suggestFinish = switch (session.getLevel()) {
+        boolean suggestFinish = switch (level) {
             case JUNIOR -> aiMessageCount >= 5;
             case SENIOR -> aiMessageCount >= 7;
         };

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -30,9 +30,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Slf4j
 @Service
@@ -134,21 +138,116 @@ public class InterviewServiceImpl implements InterviewService {
                 .map(InterviewSessionDocument::getDocument)
                 .toList();
         String systemPrompt = buildSendMessageSystemPrompt(session, documents, session.getJobPostingContent());
-        String rawResponse = claudeAiClient.chat(systemPrompt, history, request.getContent());
-
-        AiStructuredResponse parsed = parseAiStructuredResponse(rawResponse);
+        String aiResponse = claudeAiClient.chat(systemPrompt, history, request.getContent());
 
         interviewMessageRepository.save(InterviewMessage.builder()
                 .session(session)
                 .role(MessageRole.AI)
-                .content(parsed.nextQuestion())
+                .content(aiResponse)
                 .build());
 
+        List<InterviewMessage> allMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        long aiMessageCount = allMessages.stream()
+                .filter(m -> m.getRole() == MessageRole.AI)
+                .count();
+        boolean suggestFinish = switch (session.getLevel()) {
+            case JUNIOR -> aiMessageCount >= 5;
+            case SENIOR -> aiMessageCount >= 7;
+        };
+
         return InterviewSendMessageResponseDto.builder()
-                .aiResponse(parsed.nextQuestion())
+                .aiResponse(aiResponse)
                 .isCompleted(false)
-                .suggestFinish(parsed.suggestFinish())
+                .suggestFinish(suggestFinish)
                 .build();
+    }
+
+    @Override
+    public SseEmitter streamMessage(Long userId, Long sessionId, InterviewSendMessageRequestDto request) {
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(InterviewErrorCode.SESSION_NOT_FOUND));
+
+        if (session.getStatus() != InterviewStatus.IN_PROGRESS) {
+            throw new BusinessException(InterviewErrorCode.SESSION_ALREADY_COMPLETED);
+        }
+
+        saveUserMessage(session, request.getContent());
+
+        List<InterviewMessage> messages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        List<ChatMessage> history = messages.stream()
+                .map(msg -> new ChatMessage(
+                        msg.getRole() == MessageRole.AI ? "assistant" : "user",
+                        msg.getContent()))
+                .toList();
+
+        List<UserDocument> documents = interviewSessionDocumentRepository.findBySessionId(sessionId)
+                .stream()
+                .map(InterviewSessionDocument::getDocument)
+                .toList();
+        String systemPrompt = buildSendMessageSystemPrompt(session, documents, session.getJobPostingContent());
+
+        SseEmitter emitter = new SseEmitter(120_000L);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            StringBuilder aiContent = new StringBuilder();
+            try {
+                claudeAiClient.streamChat(systemPrompt, history, request.getContent())
+                        .doOnNext(token -> {
+                            aiContent.append(token);
+                            try {
+                                emitter.send(SseEmitter.event().data(token));
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .doOnComplete(() -> {
+                            saveAiMessageAndComplete(emitter, session, sessionId, aiContent.toString());
+                        })
+                        .doOnError(e -> emitter.completeWithError(e))
+                        .subscribe();
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        });
+        executor.shutdown();
+        return emitter;
+    }
+
+    @Transactional
+    public void saveUserMessage(InterviewSession session, String content) {
+        interviewMessageRepository.save(InterviewMessage.builder()
+                .session(session)
+                .role(MessageRole.USER)
+                .content(content)
+                .build());
+    }
+
+    @Transactional
+    public void saveAiMessageAndComplete(SseEmitter emitter, InterviewSession session,
+                                         Long sessionId, String aiContent) {
+        interviewMessageRepository.save(InterviewMessage.builder()
+                .session(session)
+                .role(MessageRole.AI)
+                .content(aiContent)
+                .build());
+
+        List<InterviewMessage> allMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        long aiMessageCount = allMessages.stream()
+                .filter(m -> m.getRole() == MessageRole.AI)
+                .count();
+        boolean suggestFinish = switch (session.getLevel()) {
+            case JUNIOR -> aiMessageCount >= 5;
+            case SENIOR -> aiMessageCount >= 7;
+        };
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("done")
+                    .data("{\"suggestFinish\":" + suggestFinish + "}"));
+            emitter.complete();
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
     }
 
     @Override
@@ -339,42 +438,7 @@ public class InterviewServiceImpl implements InterviewService {
     private String buildSendMessageSystemPrompt(InterviewSession session, List<UserDocument> documents,
                                                  String jobPostingContent) {
         String base = buildSystemPrompt(session, documents, jobPostingContent, null);
-        String finishCriteria = session.getLevel() == InterviewLevel.JUNIOR
-                ? "- JUNIOR: 최소 5개 이상의 질문을 통해 기술 이해도, 문제 해결, 커뮤니케이션, 경험/사례 영역을 고루 다뤘을 때"
-                : "- SENIOR: 최소 7개 이상의 질문을 통해 기술 이해도, 문제 해결, 커뮤니케이션, 경험/사례 영역에 더해 기술 깊이/아키텍처, 리더십/협업 영역까지 다뤘을 때";
-
-        return base + """
-
-                응답 형식 (반드시 아래 JSON만 반환, 다른 텍스트 없이):
-                {
-                  "nextQuestion": "다음 면접 질문 내용",
-                  "suggestFinish": false
-                }
-
-                suggestFinish를 true로 설정하는 기준:
-                """ + finishCriteria;
-    }
-
-    private record AiStructuredResponse(String nextQuestion, boolean suggestFinish) {
-    }
-
-    private AiStructuredResponse parseAiStructuredResponse(String rawResponse) {
-        try {
-            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-            String jsonStr = rawResponse;
-            int jsonStart = jsonStr.indexOf('{');
-            int jsonEnd = jsonStr.lastIndexOf('}');
-            if (jsonStart >= 0 && jsonEnd >= 0) {
-                jsonStr = jsonStr.substring(jsonStart, jsonEnd + 1);
-                com.fasterxml.jackson.databind.JsonNode node = mapper.readTree(jsonStr);
-                String nextQuestion = node.has("nextQuestion") ? node.get("nextQuestion").asText() : rawResponse;
-                boolean suggestFinish = node.has("suggestFinish") && node.get("suggestFinish").asBoolean(false);
-                return new AiStructuredResponse(nextQuestion, suggestFinish);
-            }
-        } catch (Exception e) {
-            log.warn("AI 구조화 응답 파싱 실패, 원본 텍스트 사용: {}", e.getMessage());
-        }
-        return new AiStructuredResponse(rawResponse, false);
+        return base + "\n다음 면접 질문만 텍스트로 답변해주세요. JSON 형식 불필요.";
     }
 
     private String buildFeedbackSystemPrompt(InterviewSession session) {

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -152,8 +152,8 @@ public class InterviewServiceImpl implements InterviewService {
                 .filter(m -> m.getRole() == MessageRole.AI)
                 .count();
         boolean suggestFinish = switch (session.getLevel()) {
-            case JUNIOR -> aiMessageCount >= 5;
-            case SENIOR -> aiMessageCount >= 7;
+            case JUNIOR -> aiMessageCount >= 6;
+            case SENIOR -> aiMessageCount >= 8;
         };
 
         return InterviewSendMessageResponseDto.builder()
@@ -202,7 +202,19 @@ public class InterviewServiceImpl implements InterviewService {
                             }
                         })
                         .doOnComplete(() -> {
-                            interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
+                            try {
+                                interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
+                            } catch (Exception e) {
+                                log.error("AI 메시지 저장 실패, emitter 강제 종료", e);
+                                try {
+                                    emitter.send(SseEmitter.event()
+                                            .name("done")
+                                            .data("{\"suggestFinish\":false}"));
+                                    emitter.complete();
+                                } catch (IOException ioEx) {
+                                    emitter.completeWithError(ioEx);
+                                }
+                            }
                         })
                         .doOnError(e -> emitter.completeWithError(e))
                         .subscribe();

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewMessageSaverTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewMessageSaverTest.java
@@ -1,0 +1,188 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.interview.enums.InterviewLevel;
+import com.interviewai.backend.interview.enums.MessageRole;
+import com.interviewai.backend.interview.model.InterviewMessage;
+import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.repository.InterviewMessageRepository;
+import com.interviewai.backend.interview.repository.InterviewSessionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewMessageSaverTest {
+
+    @InjectMocks
+    private InterviewMessageSaver interviewMessageSaver;
+
+    @Mock
+    private InterviewSessionRepository interviewSessionRepository;
+
+    @Mock
+    private InterviewMessageRepository interviewMessageRepository;
+
+    @Test
+    @DisplayName("기능_테스트_유저_메시지를_저장한다")
+    void 기능_테스트_유저_메시지를_저장한다() {
+        // given
+        Long sessionId = 1L;
+        String content = "Java는 객체지향 언어입니다.";
+        InterviewSession sessionRef = mock(InterviewSession.class);
+
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+
+        // when
+        interviewMessageSaver.saveUserMessage(sessionId, content);
+
+        // then
+        verify(interviewSessionRepository).getReferenceById(sessionId);
+        verify(interviewMessageRepository).save(any(InterviewMessage.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_JUNIOR_AI_메시지_5개_이하면_suggestFinish가_false다")
+    void 기능_테스트_JUNIOR_AI_메시지_5개_이하면_suggestFinish가_false다() throws IOException {
+        // given
+        Long sessionId = 1L;
+        SseEmitter emitter = mock(SseEmitter.class);
+        InterviewSession sessionRef = mock(InterviewSession.class);
+
+        List<InterviewMessage> messages = buildMessageList(5);
+
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
+
+        // when
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.JUNIOR, "좋은 답변입니다.");
+
+        // then
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(any(Throwable.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish가_true다")
+    void 기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish가_true다() throws IOException {
+        // given
+        Long sessionId = 1L;
+        SseEmitter emitter = mock(SseEmitter.class);
+        InterviewSession sessionRef = mock(InterviewSession.class);
+
+        List<InterviewMessage> messages = buildMessageList(6);
+
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
+
+        // when
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.JUNIOR, "수고하셨습니다.");
+
+        // then
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(any(Throwable.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_SENIOR_AI_메시지_7개_이하면_suggestFinish가_false다")
+    void 기능_테스트_SENIOR_AI_메시지_7개_이하면_suggestFinish가_false다() throws IOException {
+        // given
+        Long sessionId = 1L;
+        SseEmitter emitter = mock(SseEmitter.class);
+        InterviewSession sessionRef = mock(InterviewSession.class);
+
+        List<InterviewMessage> messages = buildMessageList(7);
+
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
+
+        // when
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.SENIOR, "좋은 답변입니다.");
+
+        // then
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(any(Throwable.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish가_true다")
+    void 기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish가_true다() throws IOException {
+        // given
+        Long sessionId = 1L;
+        SseEmitter emitter = mock(SseEmitter.class);
+        InterviewSession sessionRef = mock(InterviewSession.class);
+
+        List<InterviewMessage> messages = buildMessageList(8);
+
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
+
+        // when
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.SENIOR, "수고하셨습니다.");
+
+        // then
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(any(Throwable.class));
+    }
+
+    @Test
+    @DisplayName("예외_테스트_emitter_전송_실패시_completeWithError가_호출된다")
+    void 예외_테스트_emitter_전송_실패시_completeWithError가_호출된다() throws IOException {
+        // given
+        Long sessionId = 1L;
+        SseEmitter emitter = mock(SseEmitter.class);
+        InterviewSession sessionRef = mock(InterviewSession.class);
+
+        List<InterviewMessage> messages = buildMessageList(3);
+
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
+        doThrow(IOException.class).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
+
+        // when
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.JUNIOR, "답변입니다.");
+
+        // then
+        verify(emitter).completeWithError(any(IOException.class));
+        verify(emitter, never()).complete();
+    }
+
+    private List<InterviewMessage> buildMessageList(int aiCount) {
+        List<InterviewMessage> messages = new ArrayList<>();
+        InterviewSession session = mock(InterviewSession.class);
+        for (int i = 0; i < aiCount; i++) {
+            messages.add(InterviewMessage.builder()
+                    .session(session)
+                    .role(MessageRole.AI)
+                    .content("Q" + (i + 1))
+                    .build());
+            messages.add(InterviewMessage.builder()
+                    .session(session)
+                    .role(MessageRole.USER)
+                    .content("A" + (i + 1))
+                    .build());
+        }
+        return messages;
+    }
+}

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -83,6 +83,9 @@ class InterviewServiceImplTest {
     @Mock
     private JobCrawlerClient jobCrawlerClient;
 
+    @Mock
+    private InterviewMessageSaver interviewMessageSaver;
+
     private User testUser;
 
     @BeforeEach
@@ -879,7 +882,6 @@ class InterviewServiceImplTest {
                 .build();
 
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
-        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         lenient().when(claudeAiClient.streamChat(any(), any(), any())).thenReturn(Flux.just("안녕", "하세요"));

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -574,8 +574,8 @@ class InterviewServiceImplTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_JUNIOR_AI_메시지_5개_이상이면_suggestFinish_가_true_로_반환된다")
-    void 기능_테스트_JUNIOR_AI_메시지_5개_이상이면_suggestFinish_가_true_로_반환된다() {
+    @DisplayName("기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish_가_true_로_반환된다")
+    void 기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish_가_true_로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
@@ -597,7 +597,9 @@ class InterviewServiceImplTest {
                 InterviewMessage.builder().session(session).role(MessageRole.USER).content("A3").build(),
                 InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q4").build(),
                 InterviewMessage.builder().session(session).role(MessageRole.USER).content("A4").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q5").build()
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q5").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A5").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q6").build()
         );
 
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
@@ -615,8 +617,8 @@ class InterviewServiceImplTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_SENIOR_AI_메시지_7개_이상이면_suggestFinish_가_true_로_반환된다")
-    void 기능_테스트_SENIOR_AI_메시지_7개_이상이면_suggestFinish_가_true_로_반환된다() {
+    @DisplayName("기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish_가_true_로_반환된다")
+    void 기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish_가_true_로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
@@ -642,7 +644,9 @@ class InterviewServiceImplTest {
                 InterviewMessage.builder().session(session).role(MessageRole.USER).content("A5").build(),
                 InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q6").build(),
                 InterviewMessage.builder().session(session).role(MessageRole.USER).content("A6").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q7").build()
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q7").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A7").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q8").build()
         );
 
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -33,9 +33,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import reactor.core.publisher.Flux;
 
@@ -44,6 +48,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -938,6 +944,161 @@ class InterviewServiceImplTest {
         assertThatThrownBy(() -> interviewService.streamMessage(userId, sessionId, request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("완료");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_sendTokenToEmitter_정상적으로_토큰을_전송한다")
+    void 기능_테스트_sendTokenToEmitter_정상적으로_토큰을_전송한다() throws IOException {
+        // given
+        SseEmitter emitter = mock(SseEmitter.class);
+
+        // when
+        interviewService.sendTokenToEmitter(emitter, "안녕하세요");
+
+        // then
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+    }
+
+    @Test
+    @DisplayName("예외_테스트_sendTokenToEmitter_IOException_발생_시_RuntimeException으로_래핑된다")
+    void 예외_테스트_sendTokenToEmitter_IOException_발생_시_RuntimeException으로_래핑된다() throws IOException {
+        // given
+        SseEmitter emitter = mock(SseEmitter.class);
+        doThrow(IOException.class).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.sendTokenToEmitter(emitter, "토큰"))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_doOnComplete_완료_시_saveAiMessageAndComplete가_호출된다")
+    void 기능_테스트_streamMessage_doOnComplete_완료_시_saveAiMessageAndComplete가_호출된다() throws InterruptedException {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(interviewMessageSaver).saveAiMessageAndComplete(any(), any(), any(), any());
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.streamChat(any(), any(), any())).willReturn(Flux.just("토큰"));
+
+        // when
+        interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        assertThat(latch.await(3, TimeUnit.SECONDS)).isTrue();
+        verify(interviewMessageSaver).saveAiMessageAndComplete(any(), eq(sessionId), eq(InterviewLevel.JUNIOR), eq("토큰"));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_doOnComplete_저장_실패_시_emitter가_오류로_종료된다")
+    void 기능_테스트_streamMessage_doOnComplete_저장_실패_시_emitter가_오류로_종료된다() throws InterruptedException {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            throw new RuntimeException("DB 오류");
+        }).when(interviewMessageSaver).saveAiMessageAndComplete(any(), any(), any(), any());
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.streamChat(any(), any(), any())).willReturn(Flux.just("토큰"));
+
+        // when
+        interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        assertThat(latch.await(3, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(100);
+        verify(interviewMessageSaver).saveAiMessageAndComplete(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_Flux_오류_발생_시_emitter가_오류로_종료된다")
+    void 기능_테스트_streamMessage_Flux_오류_발생_시_emitter가_오류로_종료된다() throws InterruptedException {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.streamChat(any(), any(), any()))
+                .willReturn(Flux.error(new RuntimeException("스트림 오류")));
+
+        // when
+        org.springframework.web.servlet.mvc.method.annotation.SseEmitter emitter =
+                interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        Thread.sleep(200);
+        assertThat(emitter).isNotNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_streamChat_예외_발생_시_emitter가_오류로_종료된다")
+    void 기능_테스트_streamMessage_streamChat_예외_발생_시_emitter가_오류로_종료된다() throws InterruptedException {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.streamChat(any(), any(), any()))
+                .willThrow(new RuntimeException("API 오류"));
+
+        // when
+        org.springframework.web.servlet.mvc.method.annotation.SseEmitter emitter =
+                interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        Thread.sleep(200);
+        assertThat(emitter).isNotNull();
     }
 
     private void setField(Object target, String fieldName, Object value) {

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -37,11 +37,14 @@ import org.springframework.data.domain.Sort;
 import java.util.List;
 import java.util.Optional;
 
+import reactor.core.publisher.Flux;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -537,8 +540,8 @@ class InterviewServiceImplTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_메시지_전송_시_suggestFinish_가_false_로_반환된다")
-    void 기능_테스트_메시지_전송_시_suggestFinish_가_false_로_반환된다() {
+    @DisplayName("기능_테스트_메시지_전송_시_AI_응답이_그대로_반환된다")
+    void 기능_테스트_메시지_전송_시_AI_응답이_그대로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
@@ -551,25 +554,25 @@ class InterviewServiceImplTest {
                 .level(InterviewLevel.JUNIOR)
                 .build();
 
-        String structuredResponse = "{\"nextQuestion\": \"다음 질문입니다.\", \"suggestFinish\": false}";
+        String aiResponse = "다음 질문입니다.";
 
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
-        given(claudeAiClient.chat(any(), any(), any())).willReturn(structuredResponse);
+        given(claudeAiClient.chat(any(), any(), any())).willReturn(aiResponse);
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
 
         // then
-        assertThat(response.getAiResponse()).isEqualTo("다음 질문입니다.");
+        assertThat(response.getAiResponse()).isEqualTo(aiResponse);
         assertThat(response.isSuggestFinish()).isFalse();
     }
 
     @Test
-    @DisplayName("기능_테스트_AI가_충분성_신호를_보내면_suggestFinish_가_true_로_반환된다")
-    void 기능_테스트_AI가_충분성_신호를_보내면_suggestFinish_가_true_로_반환된다() {
+    @DisplayName("기능_테스트_JUNIOR_AI_메시지_5개_이상이면_suggestFinish_가_true_로_반환된다")
+    void 기능_테스트_JUNIOR_AI_메시지_5개_이상이면_suggestFinish_가_true_로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
@@ -582,51 +585,75 @@ class InterviewServiceImplTest {
                 .level(InterviewLevel.JUNIOR)
                 .build();
 
-        String structuredResponse = "{\"nextQuestion\": \"수고하셨습니다. 추가로 하실 말씀이 있으신가요?\", \"suggestFinish\": true}";
+        List<InterviewMessage> existingMessages = List.of(
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q1").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A1").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q2").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A2").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q3").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A3").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q4").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A4").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q5").build()
+        );
 
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(existingMessages);
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
-        given(claudeAiClient.chat(any(), any(), any())).willReturn(structuredResponse);
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("수고하셨습니다.");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
 
         // then
-        assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다. 추가로 하실 말씀이 있으신가요?");
+        assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다.");
         assertThat(response.isSuggestFinish()).isTrue();
     }
 
     @Test
-    @DisplayName("기능_테스트_AI_응답_파싱_실패시_원본_텍스트를_nextQuestion으로_사용한다")
-    void 기능_테스트_AI_응답_파싱_실패시_원본_텍스트를_nextQuestion으로_사용한다() {
+    @DisplayName("기능_테스트_SENIOR_AI_메시지_7개_이상이면_suggestFinish_가_true_로_반환된다")
+    void 기능_테스트_SENIOR_AI_메시지_7개_이상이면_suggestFinish_가_true_로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
         InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
-        setField(request, "content", "답변입니다.");
+        setField(request, "content", "마지막 답변입니다.");
 
         InterviewSession session = InterviewSession.builder()
                 .user(testUser)
                 .mode(InterviewMode.BASIC)
-                .level(InterviewLevel.JUNIOR)
+                .level(InterviewLevel.SENIOR)
                 .build();
 
-        String plainTextResponse = "JSON이 아닌 일반 텍스트 응답입니다.";
+        List<InterviewMessage> existingMessages = List.of(
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q1").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A1").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q2").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A2").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q3").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A3").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q4").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A4").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q5").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A5").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q6").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A6").build(),
+                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q7").build()
+        );
 
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(existingMessages);
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
-        given(claudeAiClient.chat(any(), any(), any())).willReturn(plainTextResponse);
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("수고하셨습니다.");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
 
         // then
-        assertThat(response.getAiResponse()).isEqualTo(plainTextResponse);
-        assertThat(response.isSuggestFinish()).isFalse();
+        assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다.");
+        assertThat(response.isSuggestFinish()).isTrue();
     }
 
     @Test
@@ -834,6 +861,77 @@ class InterviewServiceImplTest {
         String prompt = promptCaptor.getValue();
         assertThat(prompt).contains("=== 지원자 이력서 ===");
         assertThat(prompt).contains("이력서 내용입니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_호출_시_SseEmitter_를_반환한다")
+    void 기능_테스트_streamMessage_호출_시_SseEmitter_를_반환한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "Java에 대해 설명해주세요.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        lenient().when(claudeAiClient.streamChat(any(), any(), any())).thenReturn(Flux.just("안녕", "하세요"));
+
+        // when
+        org.springframework.web.servlet.mvc.method.annotation.SseEmitter emitter =
+                interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        assertThat(emitter).isNotNull();
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_세션에_streamMessage_호출_시_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_세션에_streamMessage_호출_시_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.streamMessage(userId, sessionId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_완료된_세션에_streamMessage_호출_시_예외가_발생한다")
+    void 예외_테스트_완료된_세션에_streamMessage_호출_시_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession completedSession = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        completedSession.complete();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(completedSession));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.streamMessage(userId, sessionId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("완료");
     }
 
     private void setField(Object target, String fieldName, Object value) {


### PR DESCRIPTION
## Summary
- JUNIOR `suggestFinish` 임계값 `>= 5` → `>= 6` (사용자가 5번 답변 완료 후 표시되도록 수정)
- SENIOR `suggestFinish` 임계값 `>= 7` → `>= 8`
- `streamMessage()` `doOnComplete` 람다에 try-catch 추가 — `saveAiMessageAndComplete` 예외 발생 시 `event:done` 전송 후 emitter 강제 종료

## Test plan
- [x] JUNIOR 기준 사용자가 5번 답변한 뒤 AI 6번째 응답에서 `suggestFinish=true` 반환 확인
- [x] SENIOR 기준 사용자가 7번 답변한 뒤 AI 8번째 응답에서 `suggestFinish=true` 반환 확인
- [x] `./gradlew test` 통과 확인

Closes #36