### PR TITLE
feat(#39): AI 기반 면접 종료 제안 및 답변 품질 힌트 기능 추가

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewSendMessageResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewSendMessageResponseDto.java
@@ -10,4 +10,6 @@ public class InterviewSendMessageResponseDto {
     private String aiResponse;
     private boolean isCompleted;
     private boolean suggestFinish;
+    private int qualityScore;
+    private String qualityHint;
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewEvaluation.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewEvaluation.java
@@ -1,0 +1,8 @@
+package com.interviewai.backend.interview.service;
+
+public record InterviewEvaluation(boolean suggestFinish, int qualityScore, String qualityHint) {
+
+    public static InterviewEvaluation fallback() {
+        return new InterviewEvaluation(false, 50, "답변이 접수되었습니다.");
+    }
+}

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
@@ -1,6 +1,5 @@
 package com.interviewai.backend.interview.service;
 
-import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.MessageRole;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
@@ -14,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -36,7 +34,7 @@ public class InterviewMessageSaver {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveAiMessageAndComplete(SseEmitter emitter, Long sessionId,
-                                         InterviewLevel level, String aiContent) {
+                                         String aiContent, InterviewEvaluation eval) {
         InterviewSession sessionRef = interviewSessionRepository.getReferenceById(sessionId);
         interviewMessageRepository.save(InterviewMessage.builder()
                 .session(sessionRef)
@@ -44,19 +42,15 @@ public class InterviewMessageSaver {
                 .content(aiContent)
                 .build());
 
-        List<InterviewMessage> allMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
-        long aiMessageCount = allMessages.stream()
-                .filter(m -> m.getRole() == MessageRole.AI)
-                .count();
-        boolean suggestFinish = switch (level) {
-            case JUNIOR -> aiMessageCount >= 6;
-            case SENIOR -> aiMessageCount >= 8;
-        };
+        String qualityHintEscaped = eval.qualityHint().replace("\\", "\\\\").replace("\"", "\\\"");
+        String doneData = "{\"suggestFinish\":" + eval.suggestFinish()
+                + ",\"qualityScore\":" + eval.qualityScore()
+                + ",\"qualityHint\":\"" + qualityHintEscaped + "\"}";
 
         try {
             emitter.send(SseEmitter.event()
                     .name("done")
-                    .data("{\"suggestFinish\":" + suggestFinish + "}"));
+                    .data(doneData));
             emitter.complete();
         } catch (IOException e) {
             emitter.completeWithError(e);

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -147,19 +147,14 @@ public class InterviewServiceImpl implements InterviewService {
                 .content(aiResponse)
                 .build());
 
-        List<InterviewMessage> allMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
-        long aiMessageCount = allMessages.stream()
-                .filter(m -> m.getRole() == MessageRole.AI)
-                .count();
-        boolean suggestFinish = switch (session.getLevel()) {
-            case JUNIOR -> aiMessageCount >= 6;
-            case SENIOR -> aiMessageCount >= 8;
-        };
+        InterviewEvaluation eval = evaluateWithAi(session, history, aiResponse);
 
         return InterviewSendMessageResponseDto.builder()
                 .aiResponse(aiResponse)
                 .isCompleted(false)
-                .suggestFinish(suggestFinish)
+                .suggestFinish(eval.suggestFinish())
+                .qualityScore(eval.qualityScore())
+                .qualityHint(eval.qualityHint())
                 .build();
     }
 
@@ -199,7 +194,8 @@ public class InterviewServiceImpl implements InterviewService {
                         })
                         .doOnComplete(() -> {
                             try {
-                                interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, session.getLevel(), aiContent.toString());
+                                InterviewEvaluation eval = evaluateWithAi(session, history, aiContent.toString());
+                                interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, aiContent.toString(), eval);
                             } catch (Exception e) {
                                 log.error("AI 메시지 저장 실패, emitter 강제 종료", e);
                                 emitter.completeWithError(e);
@@ -436,6 +432,63 @@ public class InterviewServiceImpl implements InterviewService {
             sb.append(message.getContent()).append("\n\n");
         }
         return sb.toString();
+    }
+
+    InterviewEvaluation evaluateWithAi(InterviewSession session, List<ChatMessage> history, String aiResponse) {
+        String evalPrompt = buildEvalPrompt(session, history, aiResponse);
+        String evalJson = claudeAiClient.chat(evalPrompt, List.of(), "위 지시에 따라 JSON으로만 응답해주세요.");
+        return parseEvaluation(evalJson);
+    }
+
+    private String buildEvalPrompt(InterviewSession session, List<ChatMessage> history, String aiResponse) {
+        StringBuilder prompt = new StringBuilder();
+        String levelDesc = session.getLevel() == InterviewLevel.JUNIOR ? "신입 개발자" : "경력 개발자";
+
+        prompt.append("당신은 기술 면접 평가 전문가입니다.\n");
+        prompt.append("아래 면접 대화에서 지원자의 마지막 답변을 평가하고, 면접 종료 시점인지 판단해주세요.\n\n");
+        prompt.append("면접 레벨: ").append(levelDesc).append("\n");
+        if (session.getJobTitle() != null) {
+            prompt.append("지원 직무: ").append(session.getJobTitle()).append("\n");
+        }
+        prompt.append("\n=== 면접 대화 ===\n");
+        for (ChatMessage msg : history) {
+            String role = "assistant".equals(msg.role()) ? "[면접관]" : "[지원자]";
+            prompt.append(role).append("\n").append(msg.content()).append("\n\n");
+        }
+        prompt.append("[면접관]\n").append(aiResponse).append("\n\n");
+        prompt.append("""
+                위 대화를 바탕으로 다음 JSON 형식으로만 응답하세요:
+                {
+                  "suggestFinish": false,
+                  "qualityScore": 75,
+                  "qualityHint": "시간복잡도 설명은 좋았으나 공간복잡도 언급이 부족했어요."
+                }
+
+                - suggestFinish: 주요 기술 주제가 충분히 다루어졌으면 true, 아직 부족하면 false
+                - qualityScore: 0-100 정수 (지원자 마지막 답변의 기술 정확성과 완성도)
+                - qualityHint: 한국어 한 줄 피드백 (지원자 마지막 답변에 대해, 100자 이내)
+                """);
+        return prompt.toString();
+    }
+
+    private InterviewEvaluation parseEvaluation(String evalJson) {
+        try {
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            String jsonStr = evalJson;
+            int jsonStart = jsonStr.indexOf('{');
+            int jsonEnd = jsonStr.lastIndexOf('}');
+            if (jsonStart >= 0 && jsonEnd >= 0) {
+                jsonStr = jsonStr.substring(jsonStart, jsonEnd + 1);
+                com.fasterxml.jackson.databind.JsonNode node = mapper.readTree(jsonStr);
+                boolean suggestFinish = node.has("suggestFinish") && node.get("suggestFinish").asBoolean(false);
+                int qualityScore = node.has("qualityScore") ? node.get("qualityScore").asInt(50) : 50;
+                String qualityHint = node.has("qualityHint") ? node.get("qualityHint").asText() : "답변이 접수되었습니다.";
+                return new InterviewEvaluation(suggestFinish, qualityScore, qualityHint);
+            }
+        } catch (Exception e) {
+            log.warn("평가 JSON 파싱 실패, fallback 사용: {}", e.getMessage());
+        }
+        return InterviewEvaluation.fallback();
     }
 
     void sendTokenToEmitter(SseEmitter emitter, String token) {

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewMessageSaverTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewMessageSaverTest.java
@@ -1,6 +1,5 @@
 package com.interviewai.backend.interview.service;
 
-import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.MessageRole;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
@@ -15,10 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -54,95 +52,65 @@ class InterviewMessageSaverTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_JUNIOR_AI_메시지_5개_이하면_suggestFinish가_false다")
-    void 기능_테스트_JUNIOR_AI_메시지_5개_이하면_suggestFinish가_false다() throws IOException {
+    @DisplayName("기능_테스트_AI_메시지를_저장하고_suggestFinish_false로_완료한다")
+    void 기능_테스트_AI_메시지를_저장하고_suggestFinish_false로_완료한다() throws IOException {
         // given
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-
-        List<InterviewMessage> messages = buildMessageList(5);
+        InterviewEvaluation eval = new InterviewEvaluation(false, 70, "좋은 답변이었습니다.");
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
 
         // when
-        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.JUNIOR, "좋은 답변입니다.");
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, "좋은 답변입니다.", eval);
 
         // then
-        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).send(argThat((SseEmitter.SseEventBuilder builder) -> true));
         verify(emitter).complete();
         verify(emitter, never()).completeWithError(any(Throwable.class));
     }
 
     @Test
-    @DisplayName("기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish가_true다")
-    void 기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish가_true다() throws IOException {
+    @DisplayName("기능_테스트_AI_메시지를_저장하고_suggestFinish_true로_완료한다")
+    void 기능_테스트_AI_메시지를_저장하고_suggestFinish_true로_완료한다() throws IOException {
         // given
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-
-        List<InterviewMessage> messages = buildMessageList(6);
+        InterviewEvaluation eval = new InterviewEvaluation(true, 85, "전반적으로 훌륭한 답변이었습니다.");
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
 
         // when
-        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.JUNIOR, "수고하셨습니다.");
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, "수고하셨습니다.", eval);
 
         // then
-        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).send(argThat((SseEmitter.SseEventBuilder builder) -> true));
         verify(emitter).complete();
         verify(emitter, never()).completeWithError(any(Throwable.class));
     }
 
     @Test
-    @DisplayName("기능_테스트_SENIOR_AI_메시지_7개_이하면_suggestFinish가_false다")
-    void 기능_테스트_SENIOR_AI_메시지_7개_이하면_suggestFinish가_false다() throws IOException {
+    @DisplayName("기능_테스트_qualityScore와_qualityHint가_SSE_done_이벤트에_포함된다")
+    void 기능_테스트_qualityScore와_qualityHint가_SSE_done_이벤트에_포함된다() throws IOException {
         // given
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-
-        List<InterviewMessage> messages = buildMessageList(7);
+        InterviewEvaluation eval = new InterviewEvaluation(false, 75, "시간복잡도 언급이 좋았어요.");
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
 
         // when
-        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.SENIOR, "좋은 답변입니다.");
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, "답변입니다.", eval);
 
         // then
         verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
         verify(emitter).complete();
-        verify(emitter, never()).completeWithError(any(Throwable.class));
-    }
-
-    @Test
-    @DisplayName("기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish가_true다")
-    void 기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish가_true다() throws IOException {
-        // given
-        Long sessionId = 1L;
-        SseEmitter emitter = mock(SseEmitter.class);
-        InterviewSession sessionRef = mock(InterviewSession.class);
-
-        List<InterviewMessage> messages = buildMessageList(8);
-
-        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
-        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
-
-        // when
-        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.SENIOR, "수고하셨습니다.");
-
-        // then
-        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
-        verify(emitter).complete();
-        verify(emitter, never()).completeWithError(any(Throwable.class));
     }
 
     @Test
@@ -152,37 +120,17 @@ class InterviewMessageSaverTest {
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-
-        List<InterviewMessage> messages = buildMessageList(3);
+        InterviewEvaluation eval = InterviewEvaluation.fallback();
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(messages);
         doThrow(IOException.class).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
 
         // when
-        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, InterviewLevel.JUNIOR, "답변입니다.");
+        interviewMessageSaver.saveAiMessageAndComplete(emitter, sessionId, "답변입니다.", eval);
 
         // then
         verify(emitter).completeWithError(any(IOException.class));
         verify(emitter, never()).complete();
-    }
-
-    private List<InterviewMessage> buildMessageList(int aiCount) {
-        List<InterviewMessage> messages = new ArrayList<>();
-        InterviewSession session = mock(InterviewSession.class);
-        for (int i = 0; i < aiCount; i++) {
-            messages.add(InterviewMessage.builder()
-                    .session(session)
-                    .role(MessageRole.AI)
-                    .content("Q" + (i + 1))
-                    .build());
-            messages.add(InterviewMessage.builder()
-                    .session(session)
-                    .role(MessageRole.USER)
-                    .content("A" + (i + 1))
-                    .build());
-        }
-        return messages;
     }
 }

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -569,7 +569,8 @@ class InterviewServiceImplTest {
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
-        given(claudeAiClient.chat(any(), any(), any())).willReturn(aiResponse);
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn(aiResponse, "{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋은 답변이었습니다.\"}");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
@@ -577,11 +578,13 @@ class InterviewServiceImplTest {
         // then
         assertThat(response.getAiResponse()).isEqualTo(aiResponse);
         assertThat(response.isSuggestFinish()).isFalse();
+        assertThat(response.getQualityScore()).isEqualTo(70);
+        assertThat(response.getQualityHint()).isEqualTo("좋은 답변이었습니다.");
     }
 
     @Test
-    @DisplayName("기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish_가_true_로_반환된다")
-    void 기능_테스트_JUNIOR_AI_메시지_6개_이상이면_suggestFinish_가_true_로_반환된다() {
+    @DisplayName("기능_테스트_AI_평가_결과_suggestFinish가_true면_true로_반환된다")
+    void 기능_테스트_AI_평가_결과_suggestFinish가_true면_true로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
@@ -594,25 +597,12 @@ class InterviewServiceImplTest {
                 .level(InterviewLevel.JUNIOR)
                 .build();
 
-        List<InterviewMessage> existingMessages = List.of(
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q1").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A1").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q2").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A2").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q3").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A3").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q4").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A4").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q5").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A5").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q6").build()
-        );
-
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(existingMessages);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
-        given(claudeAiClient.chat(any(), any(), any())).willReturn("수고하셨습니다.");
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("수고하셨습니다.", "{\"suggestFinish\":true,\"qualityScore\":88,\"qualityHint\":\"전반적으로 훌륭했습니다.\"}");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
@@ -620,16 +610,17 @@ class InterviewServiceImplTest {
         // then
         assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다.");
         assertThat(response.isSuggestFinish()).isTrue();
+        assertThat(response.getQualityScore()).isEqualTo(88);
     }
 
     @Test
-    @DisplayName("기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish_가_true_로_반환된다")
-    void 기능_테스트_SENIOR_AI_메시지_8개_이상이면_suggestFinish_가_true_로_반환된다() {
+    @DisplayName("기능_테스트_AI_평가_JSON_파싱_실패시_fallback_값으로_반환된다")
+    void 기능_테스트_AI_평가_JSON_파싱_실패시_fallback_값으로_반환된다() {
         // given
         Long userId = 1L;
         Long sessionId = 1L;
         InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
-        setField(request, "content", "마지막 답변입니다.");
+        setField(request, "content", "답변입니다.");
 
         InterviewSession session = InterviewSession.builder()
                 .user(testUser)
@@ -637,36 +628,71 @@ class InterviewServiceImplTest {
                 .level(InterviewLevel.SENIOR)
                 .build();
 
-        List<InterviewMessage> existingMessages = List.of(
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q1").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A1").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q2").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A2").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q3").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A3").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q4").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A4").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q5").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A5").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q6").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A6").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q7").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.USER).content("A7").build(),
-                InterviewMessage.builder().session(session).role(MessageRole.AI).content("Q8").build()
-        );
-
         given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
-        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(existingMessages);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
-        given(claudeAiClient.chat(any(), any(), any())).willReturn("수고하셨습니다.");
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("다음 질문입니다.", "invalid json response");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
 
         // then
-        assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다.");
-        assertThat(response.isSuggestFinish()).isTrue();
+        assertThat(response.isSuggestFinish()).isFalse();
+        assertThat(response.getQualityScore()).isEqualTo(50);
+        assertThat(response.getQualityHint()).isEqualTo("답변이 접수되었습니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildEvalPrompt_레벨과_jobTitle이_포함된_프롬프트를_생성한다")
+    void 기능_테스트_buildEvalPrompt_레벨과_jobTitle이_포함된_프롬프트를_생성한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .jobTitle("백엔드 개발자")
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("다음 질문입니다.", "{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋았어요.\"}");
+
+        // when & then (프롬프트 내용 검증은 실제 호출을 통해 간접 확인)
+        InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
+        assertThat(response).isNotNull();
+        verify(claudeAiClient, times(2)).chat(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_evaluateWithAi_정상_JSON_파싱된_결과를_반환한다")
+    void 기능_테스트_evaluateWithAi_정상_JSON_파싱된_결과를_반환한다() {
+        // given
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("{\"suggestFinish\":true,\"qualityScore\":82,\"qualityHint\":\"정확한 답변이었습니다.\"}");
+
+        // when
+        InterviewEvaluation eval = interviewService.evaluateWithAi(session, List.of(), "AI 응답");
+
+        // then
+        assertThat(eval.suggestFinish()).isTrue();
+        assertThat(eval.qualityScore()).isEqualTo(82);
+        assertThat(eval.qualityHint()).isEqualTo("정확한 답변이었습니다.");
     }
 
     @Test
@@ -997,13 +1023,15 @@ class InterviewServiceImplTest {
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.streamChat(any(), any(), any())).willReturn(Flux.just("토큰"));
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋은 답변이었습니다.\"}");
 
         // when
         interviewService.streamMessage(userId, sessionId, request);
 
         // then
         assertThat(latch.await(3, TimeUnit.SECONDS)).isTrue();
-        verify(interviewMessageSaver).saveAiMessageAndComplete(any(), eq(sessionId), eq(InterviewLevel.JUNIOR), eq("토큰"));
+        verify(interviewMessageSaver).saveAiMessageAndComplete(any(), eq(sessionId), eq("토큰"), any(InterviewEvaluation.class));
     }
 
     @Test
@@ -1031,6 +1059,8 @@ class InterviewServiceImplTest {
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.streamChat(any(), any(), any())).willReturn(Flux.just("토큰"));
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋은 답변이었습니다.\"}");
 
         // when
         interviewService.streamMessage(userId, sessionId, request);


### PR DESCRIPTION
## Summary
- AI 평가 파이프라인 도입: 메시지 응답 후 Claude가 JSON으로 평가 → 코드가 결정
- `suggestFinish`: 면접 종료 권장 여부를 AI가 판단 (카운트 기반 제거)
- `qualityScore` / `qualityHint`: 답변 품질 점수 및 힌트를 SSE `done` 이벤트로 전달
- `InterviewMessageSaver` 리팩토링: `InterviewEvaluation` 파라미터 기반으로 변경

## Test plan
- [x] `POST /interviews/{id}/messages` 응답 SSE `done` 이벤트에 `suggestFinish`, `qualityScore`, `qualityHint` 포함 확인
- [x] AI 응답 파싱 실패 시 fallback(`suggestFinish: false`, `qualityScore: 50`) 동작 확인
- [x] 스트리밍 종료 후 `done` 이벤트 정상 수신 확인

Closes #39