### PR TITLE
refactor(#41): 답변 품질 평가 방식 개선 — 숫자 점수 제거, AnswerLevel 3단계 정성 평가로 전환

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewFeedbackResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewFeedbackResponseDto.java
@@ -1,5 +1,6 @@
 package com.interviewai.backend.interview.controller.dto;
 
+import com.interviewai.backend.interview.enums.AnswerLevel;
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ public class InterviewFeedbackResponseDto {
 
     private Long id;
     private Long sessionId;
-    private Integer overallScore;
+    private AnswerLevel overallLevel;
     private String strengths;
     private String improvements;
     private String fullReport;
@@ -22,7 +23,7 @@ public class InterviewFeedbackResponseDto {
         return InterviewFeedbackResponseDto.builder()
                 .id(feedback.getId())
                 .sessionId(feedback.getSession().getId())
-                .overallScore(feedback.getOverallScore())
+                .overallLevel(feedback.getOverallLevel())
                 .strengths(feedback.getStrengths())
                 .improvements(feedback.getImprovements())
                 .fullReport(feedback.getFullReport())

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewSendMessageResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewSendMessageResponseDto.java
@@ -1,5 +1,6 @@
 package com.interviewai.backend.interview.controller.dto;
 
+import com.interviewai.backend.interview.enums.AnswerLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,6 @@ public class InterviewSendMessageResponseDto {
     private String aiResponse;
     private boolean isCompleted;
     private boolean suggestFinish;
-    private int qualityScore;
+    private AnswerLevel answerLevel;
     private String qualityHint;
 }

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStatsResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStatsResponseDto.java
@@ -12,7 +12,6 @@ public class InterviewStatsResponseDto {
     private long totalCount;
     private long completedCount;
     private long cancelledCount;
-    private Double averageScore;
     private Map<String, Long> modeDistribution;
     private Map<String, Long> levelDistribution;
 }

--- a/src/main/java/com/interviewai/backend/interview/enums/AnswerLevel.java
+++ b/src/main/java/com/interviewai/backend/interview/enums/AnswerLevel.java
@@ -1,0 +1,7 @@
+package com.interviewai.backend.interview.enums;
+
+public enum AnswerLevel {
+    PASS,              // 핵심 개념을 정확히 이해하고 설명할 수 있음
+    NEEDS_IMPROVEMENT, // 기본 개념은 알지만 중요한 부분이 빠짐
+    STUDY_REQUIRED     // 개념 이해가 부족하거나 핵심을 놓침
+}

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewFeedback.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewFeedback.java
@@ -1,5 +1,6 @@
 package com.interviewai.backend.interview.model;
 
+import com.interviewai.backend.interview.enums.AnswerLevel;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -20,7 +21,8 @@ public class InterviewFeedback {
     @JoinColumn(name = "session_id", nullable = false, unique = true)
     private InterviewSession session;
 
-    private Integer overallScore;
+    @Enumerated(EnumType.STRING)
+    private AnswerLevel overallLevel;
 
     @Column(columnDefinition = "TEXT")
     private String strengths;
@@ -36,10 +38,10 @@ public class InterviewFeedback {
     private LocalDateTime createdAt;
 
     @Builder
-    public InterviewFeedback(InterviewSession session, Integer overallScore,
+    public InterviewFeedback(InterviewSession session, AnswerLevel overallLevel,
                              String strengths, String improvements, String fullReport) {
         this.session = session;
-        this.overallScore = overallScore;
+        this.overallLevel = overallLevel;
         this.strengths = strengths;
         this.improvements = improvements;
         this.fullReport = fullReport;

--- a/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
+++ b/src/main/java/com/interviewai/backend/interview/repository/InterviewFeedbackRepository.java
@@ -2,7 +2,6 @@ package com.interviewai.backend.interview.repository;
 
 import com.interviewai.backend.interview.model.InterviewFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,9 +9,6 @@ import java.util.Optional;
 public interface InterviewFeedbackRepository extends JpaRepository<InterviewFeedback, Long> {
 
     Optional<InterviewFeedback> findBySessionId(Long sessionId);
-
-    @Query("SELECT AVG(f.overallScore) FROM InterviewFeedback f WHERE f.session.user.id = :userId")
-    Double findAverageScoreByUserId(Long userId);
 
     void deleteBySessionId(Long sessionId);
 

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewEvaluation.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewEvaluation.java
@@ -1,8 +1,10 @@
 package com.interviewai.backend.interview.service;
 
-public record InterviewEvaluation(boolean suggestFinish, int qualityScore, String qualityHint) {
+import com.interviewai.backend.interview.enums.AnswerLevel;
+
+public record InterviewEvaluation(boolean suggestFinish, AnswerLevel answerLevel, String qualityHint) {
 
     public static InterviewEvaluation fallback() {
-        return new InterviewEvaluation(false, 50, "답변이 접수되었습니다.");
+        return new InterviewEvaluation(false, AnswerLevel.NEEDS_IMPROVEMENT, "답변이 접수되었습니다.");
     }
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewMessageSaver.java
@@ -44,8 +44,8 @@ public class InterviewMessageSaver {
 
         String qualityHintEscaped = eval.qualityHint().replace("\\", "\\\\").replace("\"", "\\\"");
         String doneData = "{\"suggestFinish\":" + eval.suggestFinish()
-                + ",\"qualityScore\":" + eval.qualityScore()
-                + ",\"qualityHint\":\"" + qualityHintEscaped + "\"}";
+                + ",\"answerLevel\":\"" + eval.answerLevel().name()
+                + "\",\"qualityHint\":\"" + qualityHintEscaped + "\"}";
 
         try {
             emitter.send(SseEmitter.event()

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -8,6 +8,7 @@ import com.interviewai.backend.common.exception.BusinessException;
 import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.document.repository.UserDocumentRepository;
 import com.interviewai.backend.interview.controller.dto.*;
+import com.interviewai.backend.interview.enums.AnswerLevel;
 import com.interviewai.backend.interview.enums.InterviewErrorCode;
 import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.InterviewMode;
@@ -153,7 +154,7 @@ public class InterviewServiceImpl implements InterviewService {
                 .aiResponse(aiResponse)
                 .isCompleted(false)
                 .suggestFinish(eval.suggestFinish())
-                .qualityScore(eval.qualityScore())
+                .answerLevel(eval.answerLevel())
                 .qualityHint(eval.qualityHint())
                 .build();
     }
@@ -307,7 +308,6 @@ public class InterviewServiceImpl implements InterviewService {
         long totalCount = interviewSessionRepository.countByUserId(userId);
         long completedCount = interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.COMPLETED);
         long cancelledCount = interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.CANCELLED);
-        Double averageScore = interviewFeedbackRepository.findAverageScoreByUserId(userId);
 
         java.util.Map<String, Long> modeDistribution = new java.util.LinkedHashMap<>();
         for (InterviewMode mode : InterviewMode.values()) {
@@ -323,7 +323,6 @@ public class InterviewServiceImpl implements InterviewService {
                 .totalCount(totalCount)
                 .completedCount(completedCount)
                 .cancelledCount(cancelledCount)
-                .averageScore(averageScore)
                 .modeDistribution(modeDistribution)
                 .levelDistribution(levelDistribution)
                 .build();
@@ -403,25 +402,24 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     private String buildFeedbackSystemPrompt(InterviewSession session) {
+        String target = session.getLevel() == InterviewLevel.JUNIOR ? "신입 개발자" : "경력 개발자";
         return """
                 당신은 기술 면접을 평가하는 전문가입니다.
                 다음 면접 대화를 분석하여 구조화된 피드백을 제공해주세요.
 
                 다음 형식으로 정확히 응답해주세요 (JSON 형식):
                 {
-                  "overallScore": 75,
+                  "overallLevel": "NEEDS_IMPROVEMENT",
                   "strengths": "잘한 점 1.\\n잘한 점 2.\\n잘한 점 3.",
                   "improvements": "개선점 1.\\n개선점 2.\\n개선점 3.",
                   "fullReport": "종합 평가 내용..."
                 }
 
-                점수는 0-100 사이의 정수로, 다음 기준으로 평가합니다:
-                - 기술 지식의 정확성 (40점)
-                - 의사소통 능력 (20점)
-                - 문제 해결 접근법 (20점)
-                - 경험 및 예시의 적절성 (20점)
-                """ + "대상: " + (session.getLevel() == com.interviewai.backend.interview.enums.InterviewLevel.JUNIOR
-                ? "신입 개발자" : "경력 개발자");
+                overallLevel은 반드시 다음 중 하나만 사용하세요:
+                - PASS: 기술 이해도, 의사소통, 문제 해결 능력 모두 충분함
+                - NEEDS_IMPROVEMENT: 일부 중요 영역에서 보완이 필요함
+                - STUDY_REQUIRED: 핵심 기술 이해 및 설명 능력이 전반적으로 부족함
+                """ + "대상: " + target;
     }
 
     private String buildConversationText(List<InterviewMessage> messages) {
@@ -460,12 +458,15 @@ public class InterviewServiceImpl implements InterviewService {
                 위 대화를 바탕으로 다음 JSON 형식으로만 응답하세요:
                 {
                   "suggestFinish": false,
-                  "qualityScore": 75,
+                  "answerLevel": "NEEDS_IMPROVEMENT",
                   "qualityHint": "시간복잡도 설명은 좋았으나 공간복잡도 언급이 부족했어요."
                 }
 
                 - suggestFinish: 주요 기술 주제가 충분히 다루어졌으면 true, 아직 부족하면 false
-                - qualityScore: 0-100 정수 (지원자 마지막 답변의 기술 정확성과 완성도)
+                - answerLevel: 지원자 마지막 답변 수준 (반드시 다음 중 하나만 사용)
+                  * PASS: 핵심 개념을 정확히 이해하고 설명할 수 있음
+                  * NEEDS_IMPROVEMENT: 기본 개념은 알지만 중요한 부분이 빠짐
+                  * STUDY_REQUIRED: 개념 이해가 부족하거나 핵심을 놓침
                 - qualityHint: 한국어 한 줄 피드백 (지원자 마지막 답변에 대해, 100자 이내)
                 """);
         return prompt.toString();
@@ -481,9 +482,15 @@ public class InterviewServiceImpl implements InterviewService {
                 jsonStr = jsonStr.substring(jsonStart, jsonEnd + 1);
                 com.fasterxml.jackson.databind.JsonNode node = mapper.readTree(jsonStr);
                 boolean suggestFinish = node.has("suggestFinish") && node.get("suggestFinish").asBoolean(false);
-                int qualityScore = node.has("qualityScore") ? node.get("qualityScore").asInt(50) : 50;
+                String levelStr = node.has("answerLevel") ? node.get("answerLevel").asText() : "NEEDS_IMPROVEMENT";
+                AnswerLevel answerLevel;
+                try {
+                    answerLevel = AnswerLevel.valueOf(levelStr);
+                } catch (IllegalArgumentException ex) {
+                    answerLevel = AnswerLevel.NEEDS_IMPROVEMENT;
+                }
                 String qualityHint = node.has("qualityHint") ? node.get("qualityHint").asText() : "답변이 접수되었습니다.";
-                return new InterviewEvaluation(suggestFinish, qualityScore, qualityHint);
+                return new InterviewEvaluation(suggestFinish, answerLevel, qualityHint);
             }
         } catch (Exception e) {
             log.warn("평가 JSON 파싱 실패, fallback 사용: {}", e.getMessage());
@@ -500,7 +507,7 @@ public class InterviewServiceImpl implements InterviewService {
     }
 
     private InterviewFeedback parseFeedbackAndSave(InterviewSession session, String feedbackJson) {
-        int overallScore = 70;
+        AnswerLevel overallLevel = AnswerLevel.NEEDS_IMPROVEMENT;
         String strengths = "분석 중...";
         String improvements = "분석 중...";
         String fullReport = feedbackJson;
@@ -513,7 +520,12 @@ public class InterviewServiceImpl implements InterviewService {
             if (jsonStart >= 0 && jsonEnd >= 0) {
                 jsonStr = jsonStr.substring(jsonStart, jsonEnd + 1);
                 com.fasterxml.jackson.databind.JsonNode node = mapper.readTree(jsonStr);
-                overallScore = node.has("overallScore") ? node.get("overallScore").asInt(70) : 70;
+                String levelStr = node.has("overallLevel") ? node.get("overallLevel").asText() : "NEEDS_IMPROVEMENT";
+                try {
+                    overallLevel = AnswerLevel.valueOf(levelStr);
+                } catch (IllegalArgumentException ex) {
+                    overallLevel = AnswerLevel.NEEDS_IMPROVEMENT;
+                }
                 strengths = node.has("strengths") ? node.get("strengths").asText() : strengths;
                 improvements = node.has("improvements") ? node.get("improvements").asText() : improvements;
                 fullReport = node.has("fullReport") ? node.get("fullReport").asText() : feedbackJson;
@@ -524,7 +536,7 @@ public class InterviewServiceImpl implements InterviewService {
 
         InterviewFeedback feedback = InterviewFeedback.builder()
                 .session(session)
-                .overallScore(overallScore)
+                .overallLevel(overallLevel)
                 .strengths(strengths)
                 .improvements(improvements)
                 .fullReport(fullReport)

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewMessageSaverTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewMessageSaverTest.java
@@ -1,5 +1,6 @@
 package com.interviewai.backend.interview.service;
 
+import com.interviewai.backend.interview.enums.AnswerLevel;
 import com.interviewai.backend.interview.enums.MessageRole;
 import com.interviewai.backend.interview.model.InterviewMessage;
 import com.interviewai.backend.interview.model.InterviewSession;
@@ -58,7 +59,7 @@ class InterviewMessageSaverTest {
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-        InterviewEvaluation eval = new InterviewEvaluation(false, 70, "좋은 답변이었습니다.");
+        InterviewEvaluation eval = new InterviewEvaluation(false, AnswerLevel.NEEDS_IMPROVEMENT, "좋은 답변이었습니다.");
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
@@ -79,7 +80,7 @@ class InterviewMessageSaverTest {
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-        InterviewEvaluation eval = new InterviewEvaluation(true, 85, "전반적으로 훌륭한 답변이었습니다.");
+        InterviewEvaluation eval = new InterviewEvaluation(true, AnswerLevel.PASS, "전반적으로 훌륭한 답변이었습니다.");
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
@@ -94,13 +95,13 @@ class InterviewMessageSaverTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_qualityScore와_qualityHint가_SSE_done_이벤트에_포함된다")
-    void 기능_테스트_qualityScore와_qualityHint가_SSE_done_이벤트에_포함된다() throws IOException {
+    @DisplayName("기능_테스트_answerLevel과_qualityHint가_SSE_done_이벤트에_포함된다")
+    void 기능_테스트_answerLevel과_qualityHint가_SSE_done_이벤트에_포함된다() throws IOException {
         // given
         Long sessionId = 1L;
         SseEmitter emitter = mock(SseEmitter.class);
         InterviewSession sessionRef = mock(InterviewSession.class);
-        InterviewEvaluation eval = new InterviewEvaluation(false, 75, "시간복잡도 언급이 좋았어요.");
+        InterviewEvaluation eval = new InterviewEvaluation(false, AnswerLevel.PASS, "시간복잡도 언급이 좋았어요.");
 
         given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(sessionRef);
         given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -1262,6 +1262,75 @@ class InterviewServiceImplTest {
         assertThat(emitter).isNotNull();
     }
 
+    @Test
+    @DisplayName("기능_테스트_finishInterview_메시지가_있을때_AI와_지원자_역할이_대화내용에_포함된다")
+    void 기능_테스트_finishInterview_메시지가_있을때_AI와_지원자_역할이_대화내용에_포함된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        InterviewMessage aiMessage = mock(InterviewMessage.class);
+        when(aiMessage.getRole()).thenReturn(MessageRole.AI);
+        when(aiMessage.getContent()).thenReturn("첫 번째 질문입니다.");
+
+        InterviewMessage userMessage = mock(InterviewMessage.class);
+        when(userMessage.getRole()).thenReturn(MessageRole.USER);
+        when(userMessage.getContent()).thenReturn("답변입니다.");
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId))
+                .willReturn(List.of(aiMessage, userMessage));
+        given(claudeAiClient.generateFeedback(any(), any()))
+                .willReturn("{\"overallLevel\":\"PASS\",\"strengths\":\"좋습니다.\",\"improvements\":\"없음\",\"fullReport\":\"훌륭합니다.\"}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.PASS);
+        verify(interviewFeedbackRepository).save(any(InterviewFeedback.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_AI_평가_잘못된_answerLevel_값이면_NEEDS_IMPROVEMENT_fallback으로_반환된다")
+    void 기능_테스트_AI_평가_잘못된_answerLevel_값이면_NEEDS_IMPROVEMENT_fallback으로_반환된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null);
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any()))
+                .willReturn("다음 질문입니다.",
+                        "{\"suggestFinish\":false,\"answerLevel\":\"INVALID_LEVEL\",\"qualityHint\":\"힌트\"}");
+
+        // when
+        InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        assertThat(response.getAnswerLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+        assertThat(response.getQualityHint()).isEqualTo("힌트");
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -309,6 +309,141 @@ class InterviewServiceImplTest {
     }
 
     @Test
+    @DisplayName("기능_테스트_finishInterview_PASS_overallLevel로_피드백을_저장한다")
+    void 기능_테스트_finishInterview_PASS_overallLevel로_피드백을_저장한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(claudeAiClient.generateFeedback(any(), any()))
+                .willReturn("{\"overallLevel\":\"PASS\",\"strengths\":\"이해도가 높습니다.\",\"improvements\":\"없음\",\"fullReport\":\"훌륭합니다.\"}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.PASS);
+        assertThat(result.getStrengths()).isEqualTo("이해도가 높습니다.");
+        verify(interviewFeedbackRepository).save(any(InterviewFeedback.class));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_finishInterview_STUDY_REQUIRED_overallLevel로_피드백을_저장한다")
+    void 기능_테스트_finishInterview_STUDY_REQUIRED_overallLevel로_피드백을_저장한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.SENIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(claudeAiClient.generateFeedback(any(), any()))
+                .willReturn("{\"overallLevel\":\"STUDY_REQUIRED\",\"strengths\":\"성실한 태도\",\"improvements\":\"기초 개념 보완 필요\",\"fullReport\":\"추가 학습이 필요합니다.\"}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.STUDY_REQUIRED);
+        assertThat(result.getImprovements()).isEqualTo("기초 개념 보완 필요");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_finishInterview_JSON_파싱_실패시_NEEDS_IMPROVEMENT_fallback으로_저장된다")
+    void 기능_테스트_finishInterview_JSON_파싱_실패시_NEEDS_IMPROVEMENT_fallback으로_저장된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(claudeAiClient.generateFeedback(any(), any())).willReturn("invalid json");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_finishInterview_잘못된_overallLevel_값이면_NEEDS_IMPROVEMENT_fallback으로_저장된다")
+    void 기능_테스트_finishInterview_잘못된_overallLevel_값이면_NEEDS_IMPROVEMENT_fallback으로_저장된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        given(claudeAiClient.generateFeedback(any(), any()))
+                .willReturn("{\"overallLevel\":\"INVALID_VALUE\",\"strengths\":\"좋아요\",\"improvements\":\"없음\",\"fullReport\":\"좋습니다.\"}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+        assertThat(result.getStrengths()).isEqualTo("좋아요");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_finishInterview_이미_완료된_세션이면_예외가_발생한다")
+    void 예외_테스트_finishInterview_이미_완료된_세션이면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession completedSession = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        completedSession.complete();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(completedSession));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.finishInterview(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("완료");
+    }
+
+    @Test
     @DisplayName("기능_테스트_진행_중인_면접_세션을_취소한다")
     void 기능_테스트_진행_중인_면접_세션을_취소한다() {
         // given

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -498,8 +498,6 @@ class InterviewServiceImplTest {
         given(interviewSessionRepository.countByUserId(userId)).willReturn(10L);
         given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.COMPLETED)).willReturn(7L);
         given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.CANCELLED)).willReturn(2L);
-        given(interviewFeedbackRepository.findAverageScoreByUserId(userId)).willReturn(78.5);
-
         given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.BASIC)).willReturn(5L);
         given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.RESUME)).willReturn(3L);
         given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.COMPANY)).willReturn(2L);
@@ -514,7 +512,6 @@ class InterviewServiceImplTest {
         assertThat(result.getTotalCount()).isEqualTo(10L);
         assertThat(result.getCompletedCount()).isEqualTo(7L);
         assertThat(result.getCancelledCount()).isEqualTo(2L);
-        assertThat(result.getAverageScore()).isEqualTo(78.5);
         assertThat(result.getModeDistribution()).containsEntry("BASIC", 5L);
         assertThat(result.getModeDistribution()).containsEntry("RESUME", 3L);
         assertThat(result.getModeDistribution()).containsEntry("COMPANY", 2L);
@@ -523,15 +520,14 @@ class InterviewServiceImplTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_피드백이_없을때_평균점수가_null이다")
-    void 기능_테스트_피드백이_없을때_평균점수가_null이다() {
+    @DisplayName("기능_테스트_인터뷰_세션이_없을때_통계가_모두_0이다")
+    void 기능_테스트_인터뷰_세션이_없을때_통계가_모두_0이다() {
         // given
         Long userId = 1L;
 
         given(interviewSessionRepository.countByUserId(userId)).willReturn(0L);
         given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.COMPLETED)).willReturn(0L);
         given(interviewSessionRepository.countByUserIdAndStatus(userId, InterviewStatus.CANCELLED)).willReturn(0L);
-        given(interviewFeedbackRepository.findAverageScoreByUserId(userId)).willReturn(null);
 
         given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.BASIC)).willReturn(0L);
         given(interviewSessionRepository.countByUserIdAndMode(userId, InterviewMode.RESUME)).willReturn(0L);
@@ -545,7 +541,7 @@ class InterviewServiceImplTest {
 
         // then
         assertThat(result.getTotalCount()).isZero();
-        assertThat(result.getAverageScore()).isNull();
+        assertThat(result.getCompletedCount()).isZero();
     }
 
     @Test
@@ -570,7 +566,7 @@ class InterviewServiceImplTest {
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.chat(any(), any(), any()))
-                .willReturn(aiResponse, "{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋은 답변이었습니다.\"}");
+                .willReturn(aiResponse, "{\"suggestFinish\":false,\"answerLevel\":\"NEEDS_IMPROVEMENT\",\"qualityHint\":\"좋은 답변이었습니다.\"}");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
@@ -578,7 +574,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response.getAiResponse()).isEqualTo(aiResponse);
         assertThat(response.isSuggestFinish()).isFalse();
-        assertThat(response.getQualityScore()).isEqualTo(70);
+        assertThat(response.getAnswerLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
         assertThat(response.getQualityHint()).isEqualTo("좋은 답변이었습니다.");
     }
 
@@ -602,7 +598,7 @@ class InterviewServiceImplTest {
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.chat(any(), any(), any()))
-                .willReturn("수고하셨습니다.", "{\"suggestFinish\":true,\"qualityScore\":88,\"qualityHint\":\"전반적으로 훌륭했습니다.\"}");
+                .willReturn("수고하셨습니다.", "{\"suggestFinish\":true,\"answerLevel\":\"PASS\",\"qualityHint\":\"전반적으로 훌륭했습니다.\"}");
 
         // when
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
@@ -610,7 +606,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response.getAiResponse()).isEqualTo("수고하셨습니다.");
         assertThat(response.isSuggestFinish()).isTrue();
-        assertThat(response.getQualityScore()).isEqualTo(88);
+        assertThat(response.getAnswerLevel()).isEqualTo(AnswerLevel.PASS);
     }
 
     @Test
@@ -640,7 +636,7 @@ class InterviewServiceImplTest {
 
         // then
         assertThat(response.isSuggestFinish()).isFalse();
-        assertThat(response.getQualityScore()).isEqualTo(50);
+        assertThat(response.getAnswerLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
         assertThat(response.getQualityHint()).isEqualTo("답변이 접수되었습니다.");
     }
 
@@ -665,7 +661,7 @@ class InterviewServiceImplTest {
         given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.chat(any(), any(), any()))
-                .willReturn("다음 질문입니다.", "{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋았어요.\"}");
+                .willReturn("다음 질문입니다.", "{\"suggestFinish\":false,\"answerLevel\":\"NEEDS_IMPROVEMENT\",\"qualityHint\":\"좋았어요.\"}");
 
         // when & then (프롬프트 내용 검증은 실제 호출을 통해 간접 확인)
         InterviewSendMessageResponseDto response = interviewService.sendMessage(userId, sessionId, request);
@@ -684,14 +680,14 @@ class InterviewServiceImplTest {
                 .build();
 
         given(claudeAiClient.chat(any(), any(), any()))
-                .willReturn("{\"suggestFinish\":true,\"qualityScore\":82,\"qualityHint\":\"정확한 답변이었습니다.\"}");
+                .willReturn("{\"suggestFinish\":true,\"answerLevel\":\"PASS\",\"qualityHint\":\"정확한 답변이었습니다.\"}");
 
         // when
         InterviewEvaluation eval = interviewService.evaluateWithAi(session, List.of(), "AI 응답");
 
         // then
         assertThat(eval.suggestFinish()).isTrue();
-        assertThat(eval.qualityScore()).isEqualTo(82);
+        assertThat(eval.answerLevel()).isEqualTo(AnswerLevel.PASS);
         assertThat(eval.qualityHint()).isEqualTo("정확한 답변이었습니다.");
     }
 
@@ -1024,7 +1020,7 @@ class InterviewServiceImplTest {
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.streamChat(any(), any(), any())).willReturn(Flux.just("토큰"));
         given(claudeAiClient.chat(any(), any(), any()))
-                .willReturn("{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋은 답변이었습니다.\"}");
+                .willReturn("{\"suggestFinish\":false,\"answerLevel\":\"NEEDS_IMPROVEMENT\",\"qualityHint\":\"좋은 답변이었습니다.\"}");
 
         // when
         interviewService.streamMessage(userId, sessionId, request);
@@ -1060,7 +1056,7 @@ class InterviewServiceImplTest {
         given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
         given(claudeAiClient.streamChat(any(), any(), any())).willReturn(Flux.just("토큰"));
         given(claudeAiClient.chat(any(), any(), any()))
-                .willReturn("{\"suggestFinish\":false,\"qualityScore\":70,\"qualityHint\":\"좋은 답변이었습니다.\"}");
+                .willReturn("{\"suggestFinish\":false,\"answerLevel\":\"NEEDS_IMPROVEMENT\",\"qualityHint\":\"좋은 답변이었습니다.\"}");
 
         // when
         interviewService.streamMessage(userId, sessionId, request);


### PR DESCRIPTION
## Summary
- `AnswerLevel` enum 신규 추가 (PASS / NEEDS_IMPROVEMENT / STUDY_REQUIRED)
- 메시지별 평가: `qualityScore(int)` → `answerLevel(AnswerLevel)` — SSE `done` 이벤트에 반영
- 최종 피드백: `overallScore(Integer)` → `overallLevel(AnswerLevel)` — 엔티티/DTO/프롬프트 모두 변경
- 통계: `averageScore` 필드 및 `findAverageScoreByUserId()` 쿼리 제거
- AI 파싱 실패 시 `NEEDS_IMPROVEMENT` fallback 적용

## Test plan
- [x] `POST /interviews/{id}/messages` 응답 SSE `done` 이벤트에 `answerLevel: "PASS"/"NEEDS_IMPROVEMENT"/"STUDY_REQUIRED"` 포함 확인
- [x] `POST /interviews/{id}/finish` 응답에 `overallLevel: "PASS"/"NEEDS_IMPROVEMENT"/"STUDY_REQUIRED"` 포함 (숫자 점수 없음)
- [x] `GET /interviews/my/stats` 응답에 `averageScore` 필드 없음 확인
- [x] AI가 잘못된 값 반환 시 `NEEDS_IMPROVEMENT` fallback 동작 확인

Closes #41