### PR TITLE
feat(#62): Context Window 2단계 — 누적 요약 레이어

### DIFF
--- a/src/main/java/com/interviewai/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/interviewai/backend/global/config/AsyncConfig.java
@@ -21,4 +21,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean("summaryExecutor")
+    public Executor summaryExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("summary-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/interviewai/backend/global/config/InterviewProperties.java
+++ b/src/main/java/com/interviewai/backend/global/config/InterviewProperties.java
@@ -23,6 +23,8 @@ public class InterviewProperties {
         private int maxEvalHistoryTokens = 4000;
         private int maxFeedbackTokens = 30000;
         private int charsPerToken = 3;
+        private int maxSummaryTokens = 500;
+        private boolean summaryEnabled = true;
     }
 
     @Getter

--- a/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
+++ b/src/main/java/com/interviewai/backend/interview/model/InterviewSession.java
@@ -50,6 +50,10 @@ public class InterviewSession {
     @Column(columnDefinition = "TEXT")
     private String systemPrompt;
 
+    @Setter
+    @Column(columnDefinition = "TEXT")
+    private String conversationSummary;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/interviewai/backend/interview/service/ConversationSummaryService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/ConversationSummaryService.java
@@ -1,0 +1,85 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.client.ClaudeAiClient;
+import com.interviewai.backend.global.config.InterviewProperties;
+import com.interviewai.backend.interview.enums.MessageRole;
+import com.interviewai.backend.interview.model.InterviewMessage;
+import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.repository.InterviewSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConversationSummaryService {
+
+    private final ClaudeAiClient claudeAiClient;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final TokenEstimator tokenEstimator;
+    private final InterviewProperties interviewProperties;
+
+    @Async("summaryExecutor")
+    @Transactional
+    public void generateSummaryAsync(Long sessionId, List<InterviewMessage> trimmedMessages) {
+        if (trimmedMessages == null || trimmedMessages.isEmpty()) {
+            return;
+        }
+
+        try {
+            InterviewSession session = interviewSessionRepository.findById(sessionId).orElse(null);
+            if (session == null) {
+                log.warn("요약 생성 실패: 세션을 찾을 수 없음 (sessionId={})", sessionId);
+                return;
+            }
+
+            String summary = generateSummary(session.getConversationSummary(), trimmedMessages);
+            session.setConversationSummary(summary);
+            log.debug("대화 요약 생성 완료 (sessionId={}, 요약 길이={}자)", sessionId, summary.length());
+        } catch (Exception e) {
+            log.error("비동기 대화 요약 생성 실패 (sessionId={})", sessionId, e);
+        }
+    }
+
+    String generateSummary(String existingSummary, List<InterviewMessage> trimmedMessages) {
+        String summaryPrompt = buildSummaryPrompt(existingSummary, trimmedMessages);
+        String summary = claudeAiClient.chat(summaryPrompt, List.of(), "위 지시에 따라 요약만 작성해주세요.");
+
+        int maxSummaryTokens = interviewProperties.getPrompt().getMaxSummaryTokens();
+        int maxChars = maxSummaryTokens * interviewProperties.getPrompt().getCharsPerToken();
+        if (summary.length() > maxChars) {
+            summary = summary.substring(0, maxChars);
+        }
+
+        return summary;
+    }
+
+    String buildSummaryPrompt(String existingSummary, List<InterviewMessage> trimmedMessages) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("당신은 기술 면접 대화 요약 전문가입니다.\n");
+        prompt.append("아래 면접 대화 내용을 요약해주세요. 요약은 다음 정보를 반드시 포함해야 합니다:\n");
+        prompt.append("1. 다뤄진 기술 주제와 질문 목록\n");
+        prompt.append("2. 지원자의 핵심 답변 내용 (잘한 점과 부족한 점)\n");
+        prompt.append("3. 면접 진행 흐름\n\n");
+        prompt.append("요약은 간결하게 300자 이내로 작성해주세요.\n\n");
+
+        if (existingSummary != null && !existingSummary.isBlank()) {
+            prompt.append("=== 기존 요약 ===\n");
+            prompt.append(existingSummary).append("\n\n");
+            prompt.append("위 기존 요약에 아래 새로운 대화 내용을 통합하여 누적 요약을 작성해주세요.\n\n");
+        }
+
+        prompt.append("=== 새로운 대화 내용 ===\n");
+        for (InterviewMessage msg : trimmedMessages) {
+            String roleLabel = msg.getRole() == MessageRole.AI ? "[면접관]" : "[지원자]";
+            prompt.append(roleLabel).append("\n").append(msg.getContent()).append("\n\n");
+        }
+
+        return prompt.toString();
+    }
+}

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewEvaluationService.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewEvaluationService.java
@@ -63,6 +63,12 @@ public class InterviewEvaluationService {
         if (session.getJobTitle() != null) {
             prompt.append("지원 직무: ").append(session.getJobTitle()).append("\n");
         }
+        String summary = session.getConversationSummary();
+        if (summary != null && !summary.isBlank()) {
+            prompt.append("\n=== 이전 대화 요약 (참고용) ===\n");
+            prompt.append(summary).append("\n\n");
+        }
+
         prompt.append("\n=== 면접 대화 ===\n");
         for (ChatMessage msg : trimmedHistory) {
             String role = "assistant".equals(msg.role()) ? "[면접관]" : "[지원자]";

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -59,6 +59,7 @@ public class InterviewServiceImpl implements InterviewService {
     private final JobCrawlerClient jobCrawlerClient;
     private final InterviewMessageSaver interviewMessageSaver;
     private final InterviewEvaluationService interviewEvaluationService;
+    private final ConversationSummaryService conversationSummaryService;
     private final TokenEstimator tokenEstimator;
     private final InterviewProperties interviewProperties;
 
@@ -172,8 +173,13 @@ public class InterviewServiceImpl implements InterviewService {
         }
 
         List<InterviewMessage> priorMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
-        List<ChatMessage> history = tokenEstimator.trimHistoryWithPriority(
+        TrimResult trimResult = tokenEstimator.trimHistoryWithPriorityAndReport(
                 priorMessages, interviewProperties.getPrompt().getMaxHistoryTokens());
+        List<ChatMessage> history = trimResult.retained();
+
+        if (trimResult.wasTrimmed() && interviewProperties.getPrompt().isSummaryEnabled()) {
+            conversationSummaryService.generateSummaryAsync(sessionId, trimResult.trimmed());
+        }
 
         interviewMessageRepository.save(InterviewMessage.builder()
                 .session(session)
@@ -215,8 +221,13 @@ public class InterviewServiceImpl implements InterviewService {
         }
 
         List<InterviewMessage> priorMessages = interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
-        List<ChatMessage> history = tokenEstimator.trimHistoryWithPriority(
+        TrimResult trimResult = tokenEstimator.trimHistoryWithPriorityAndReport(
                 priorMessages, interviewProperties.getPrompt().getMaxHistoryTokens());
+        List<ChatMessage> history = trimResult.retained();
+
+        if (trimResult.wasTrimmed() && interviewProperties.getPrompt().isSummaryEnabled()) {
+            conversationSummaryService.generateSummaryAsync(sessionId, trimResult.trimmed());
+        }
 
         interviewMessageSaver.saveUserMessage(sessionId, request.getContent());
 
@@ -453,6 +464,12 @@ public class InterviewServiceImpl implements InterviewService {
     private String buildSendMessageSystemPrompt(InterviewSession session, List<UserDocument> documents,
                                                  String jobPostingContent) {
         String base = buildSystemPrompt(session, documents, jobPostingContent, null);
+
+        String summary = session.getConversationSummary();
+        if (summary != null && !summary.isBlank()) {
+            base += "\n=== 이전 대화 요약 ===\n" + summary + "\n";
+        }
+
         return base + "\n다음 면접 질문만 텍스트로 답변해주세요. JSON 형식 불필요.";
     }
 

--- a/src/main/java/com/interviewai/backend/interview/service/TokenEstimator.java
+++ b/src/main/java/com/interviewai/backend/interview/service/TokenEstimator.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -76,18 +78,25 @@ public class TokenEstimator {
     }
 
     public List<ChatMessage> trimHistoryWithPriority(List<InterviewMessage> messages, int maxTokens) {
-        if (messages.isEmpty()) return List.of();
+        return trimHistoryWithPriorityAndReport(messages, maxTokens).retained();
+    }
+
+    public TrimResult trimHistoryWithPriorityAndReport(List<InterviewMessage> messages, int maxTokens) {
+        if (messages.isEmpty()) return new TrimResult(List.of(), List.of(), false);
 
         int totalTokens = messages.stream()
                 .mapToInt(m -> estimateTokens(m.getContent()))
                 .sum();
-        if (totalTokens <= maxTokens) return toChatMessages(messages);
+        if (totalTokens <= maxTokens) return new TrimResult(toChatMessages(messages), List.of(), false);
 
         InterviewMessage first = messages.get(0);
         int firstTokens = estimateTokens(first.getContent());
         int remainingBudget = maxTokens - firstTokens;
 
-        if (remainingBudget <= 0) return toChatMessages(List.of(first));
+        if (remainingBudget <= 0) {
+            List<InterviewMessage> trimmedMessages = messages.subList(1, messages.size());
+            return new TrimResult(toChatMessages(List.of(first)), List.copyOf(trimmedMessages), true);
+        }
 
         List<InterviewMessage> rest = messages.subList(1, messages.size());
 
@@ -124,13 +133,18 @@ public class TokenEstimator {
         result.add(first);
         result.addAll(included);
 
+        Set<InterviewMessage> retainedSet = new HashSet<>(result);
+        List<InterviewMessage> trimmedMessages = messages.stream()
+                .filter(m -> !retainedSet.contains(m))
+                .toList();
+
         long priorityKept = priority.stream().filter(included::contains).count();
         trimCounter.increment();
         int trimmedTokens = result.stream().mapToInt(m -> estimateTokens(m.getContent())).sum();
         recordMetrics("trimHistoryWithPriority", messages.size(), result.size(), trimmedTokens);
-        log.debug("중요도 기반 trimming: {} → {} 메시지 (STUDY_REQUIRED {} 보존)",
-                messages.size(), result.size(), priorityKept);
-        return toChatMessages(result);
+        log.debug("중요도 기반 trimming: {} → {} 메시지 (STUDY_REQUIRED {} 보존, {} 메시지 요약 대상)",
+                messages.size(), result.size(), priorityKept, trimmedMessages.size());
+        return new TrimResult(toChatMessages(result), trimmedMessages, true);
     }
 
     public List<ChatMessage> toChatMessages(List<InterviewMessage> messages) {

--- a/src/main/java/com/interviewai/backend/interview/service/TrimResult.java
+++ b/src/main/java/com/interviewai/backend/interview/service/TrimResult.java
@@ -1,0 +1,12 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.client.dto.ChatMessage;
+import com.interviewai.backend.interview.model.InterviewMessage;
+
+import java.util.List;
+
+public record TrimResult(
+        List<ChatMessage> retained,
+        List<InterviewMessage> trimmed,
+        boolean wasTrimmed
+) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,8 @@ interview:
     max-eval-history-tokens: 4000
     max-feedback-tokens: 30000
     chars-per-token: 3
+    max-summary-tokens: 500
+    summary-enabled: true
   sse:
     timeout-ms: 120000
 

--- a/src/test/java/com/interviewai/backend/interview/service/ConversationSummaryServiceTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/ConversationSummaryServiceTest.java
@@ -1,0 +1,313 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.client.ClaudeAiClient;
+import com.interviewai.backend.global.config.InterviewProperties;
+import com.interviewai.backend.interview.enums.MessageRole;
+import com.interviewai.backend.interview.model.InterviewMessage;
+import com.interviewai.backend.interview.model.InterviewSession;
+import com.interviewai.backend.interview.repository.InterviewSessionRepository;
+import com.interviewai.backend.user.enums.OAuthProvider;
+import com.interviewai.backend.user.enums.UserRole;
+import com.interviewai.backend.user.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ConversationSummaryServiceTest {
+
+    @InjectMocks
+    private ConversationSummaryService conversationSummaryService;
+
+    @Mock
+    private ClaudeAiClient claudeAiClient;
+
+    @Mock
+    private InterviewSessionRepository interviewSessionRepository;
+
+    @Mock
+    private TokenEstimator tokenEstimator;
+
+    @Mock
+    private InterviewProperties interviewProperties;
+
+    private User testUser;
+    private InterviewSession testSession;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("test@test.com")
+                .name("테스트유저")
+                .profileImageUrl(null)
+                .role(UserRole.USER)
+                .build();
+
+        testSession = InterviewSession.builder()
+                .user(testUser)
+                .mode(com.interviewai.backend.interview.enums.InterviewMode.BASIC)
+                .level(com.interviewai.backend.interview.enums.InterviewLevel.JUNIOR)
+                .build();
+
+        InterviewProperties.Prompt prompt = new InterviewProperties.Prompt();
+        lenient().when(interviewProperties.getPrompt()).thenReturn(prompt);
+    }
+
+    // ----------------------------------------------------------------
+    // generateSummaryAsync 테스트
+    // ----------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_generateSummaryAsync_trimmedMessages가_있으면_요약을_생성하고_세션에_저장한다")
+    void 기능_테스트_generateSummaryAsync_trimmedMessages가_있으면_요약을_생성하고_세션에_저장한다() {
+        // given
+        Long sessionId = 1L;
+        InterviewMessage msg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("Java의 특징을 설명해주세요.")
+                .build();
+
+        given(interviewSessionRepository.findById(sessionId)).willReturn(Optional.of(testSession));
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("요약 내용입니다.");
+
+        // when
+        conversationSummaryService.generateSummaryAsync(sessionId, List.of(msg));
+
+        // then
+        assertThat(testSession.getConversationSummary()).isEqualTo("요약 내용입니다.");
+        verify(claudeAiClient).chat(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateSummaryAsync_기존요약이_있으면_누적하여_갱신한다")
+    void 기능_테스트_generateSummaryAsync_기존요약이_있으면_누적하여_갱신한다() {
+        // given
+        Long sessionId = 1L;
+        testSession.setConversationSummary("기존 요약입니다.");
+
+        InterviewMessage msg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.AI)
+                .content("새로운 질문입니다.")
+                .build();
+
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        given(interviewSessionRepository.findById(sessionId)).willReturn(Optional.of(testSession));
+        given(claudeAiClient.chat(promptCaptor.capture(), any(), any())).willReturn("누적 요약입니다.");
+
+        // when
+        conversationSummaryService.generateSummaryAsync(sessionId, List.of(msg));
+
+        // then
+        assertThat(testSession.getConversationSummary()).isEqualTo("누적 요약입니다.");
+        assertThat(promptCaptor.getValue()).contains("기존 요약입니다.");
+        assertThat(promptCaptor.getValue()).contains("위 기존 요약에 아래 새로운 대화 내용을 통합하여 누적 요약을 작성해주세요.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateSummaryAsync_AI호출_실패시_로그만_남기고_종료한다")
+    void 기능_테스트_generateSummaryAsync_AI호출_실패시_로그만_남기고_종료한다() {
+        // given
+        Long sessionId = 1L;
+        InterviewMessage msg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("답변입니다.")
+                .build();
+
+        given(interviewSessionRepository.findById(sessionId)).willReturn(Optional.of(testSession));
+        given(claudeAiClient.chat(any(), any(), any())).willThrow(new RuntimeException("API 호출 실패"));
+
+        // when — 예외 없이 종료되어야 함
+        conversationSummaryService.generateSummaryAsync(sessionId, List.of(msg));
+
+        // then — conversationSummary가 설정되지 않았음을 확인
+        assertThat(testSession.getConversationSummary()).isNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateSummaryAsync_세션이_없으면_로그만_남기고_종료한다")
+    void 기능_테스트_generateSummaryAsync_세션이_없으면_로그만_남기고_종료한다() {
+        // given
+        Long sessionId = 999L;
+        InterviewMessage msg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("답변입니다.")
+                .build();
+
+        given(interviewSessionRepository.findById(sessionId)).willReturn(Optional.empty());
+
+        // when — 예외 없이 종료되어야 함
+        conversationSummaryService.generateSummaryAsync(sessionId, List.of(msg));
+
+        // then
+        verify(claudeAiClient, never()).chat(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateSummaryAsync_빈_trimmedMessages면_스킵한다")
+    void 기능_테스트_generateSummaryAsync_빈_trimmedMessages면_스킵한다() {
+        // given
+        Long sessionId = 1L;
+
+        // when
+        conversationSummaryService.generateSummaryAsync(sessionId, List.of());
+
+        // then
+        verify(interviewSessionRepository, never()).findById(any());
+        verify(claudeAiClient, never()).chat(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateSummaryAsync_null_trimmedMessages면_스킵한다")
+    void 기능_테스트_generateSummaryAsync_null_trimmedMessages면_스킵한다() {
+        // given
+        Long sessionId = 1L;
+
+        // when
+        conversationSummaryService.generateSummaryAsync(sessionId, null);
+
+        // then
+        verify(interviewSessionRepository, never()).findById(any());
+        verify(claudeAiClient, never()).chat(any(), any(), any());
+    }
+
+    // ----------------------------------------------------------------
+    // generateSummary 테스트
+    // ----------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_generateSummary_maxSummaryTokens_초과시_절삭한다")
+    void 기능_테스트_generateSummary_maxSummaryTokens_초과시_절삭한다() {
+        // given
+        InterviewProperties.Prompt prompt = new InterviewProperties.Prompt();
+        prompt.setMaxSummaryTokens(2);  // maxSummaryTokens=2, charsPerToken=3 → maxChars=6
+        given(interviewProperties.getPrompt()).willReturn(prompt);
+
+        InterviewMessage msg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("답변입니다.")
+                .build();
+
+        // AI가 6자 초과 응답을 반환
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("1234567890");
+
+        // when
+        String result = conversationSummaryService.generateSummary(null, List.of(msg));
+
+        // then — maxChars(6)로 절삭되어야 함
+        assertThat(result).hasSize(6);
+        assertThat(result).isEqualTo("123456");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateSummary_maxSummaryTokens_미초과시_절삭하지_않는다")
+    void 기능_테스트_generateSummary_maxSummaryTokens_미초과시_절삭하지_않는다() {
+        // given
+        // default: maxSummaryTokens=500, charsPerToken=3 → maxChars=1500
+        InterviewMessage msg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("답변입니다.")
+                .build();
+
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("짧은 요약");
+
+        // when
+        String result = conversationSummaryService.generateSummary(null, List.of(msg));
+
+        // then
+        assertThat(result).isEqualTo("짧은 요약");
+    }
+
+    // ----------------------------------------------------------------
+    // buildSummaryPrompt 테스트
+    // ----------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_buildSummaryPrompt_기존요약이_없으면_새로운_대화만_포함한다")
+    void 기능_테스트_buildSummaryPrompt_기존요약이_없으면_새로운_대화만_포함한다() {
+        // given
+        InterviewMessage aiMsg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.AI)
+                .content("Java란 무엇인가요?")
+                .build();
+        InterviewMessage userMsg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("Java는 객체지향 언어입니다.")
+                .build();
+
+        // when
+        String prompt = conversationSummaryService.buildSummaryPrompt(null, List.of(aiMsg, userMsg));
+
+        // then
+        assertThat(prompt).contains("=== 새로운 대화 내용 ===");
+        assertThat(prompt).contains("[면접관]");
+        assertThat(prompt).contains("Java란 무엇인가요?");
+        assertThat(prompt).contains("[지원자]");
+        assertThat(prompt).contains("Java는 객체지향 언어입니다.");
+        assertThat(prompt).doesNotContain("=== 기존 요약 ===");
+        assertThat(prompt).doesNotContain("위 기존 요약에 아래 새로운 대화 내용을 통합하여");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildSummaryPrompt_기존요약이_있으면_누적지시가_포함된다")
+    void 기능_테스트_buildSummaryPrompt_기존요약이_있으면_누적지시가_포함된다() {
+        // given
+        String existingSummary = "1차 면접 요약: Java 기초 질문을 다뤘습니다.";
+        InterviewMessage userMsg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("Spring Boot는 무엇인가요?")
+                .build();
+
+        // when
+        String prompt = conversationSummaryService.buildSummaryPrompt(existingSummary, List.of(userMsg));
+
+        // then
+        assertThat(prompt).contains("=== 기존 요약 ===");
+        assertThat(prompt).contains(existingSummary);
+        assertThat(prompt).contains("위 기존 요약에 아래 새로운 대화 내용을 통합하여 누적 요약을 작성해주세요.");
+        assertThat(prompt).contains("=== 새로운 대화 내용 ===");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildSummaryPrompt_기존요약이_blank이면_누적지시가_포함되지_않는다")
+    void 기능_테스트_buildSummaryPrompt_기존요약이_blank이면_누적지시가_포함되지_않는다() {
+        // given
+        InterviewMessage userMsg = InterviewMessage.builder()
+                .session(testSession)
+                .role(MessageRole.USER)
+                .content("답변입니다.")
+                .build();
+
+        // when — blank 문자열 전달
+        String prompt = conversationSummaryService.buildSummaryPrompt("   ", List.of(userMsg));
+
+        // then
+        assertThat(prompt).doesNotContain("=== 기존 요약 ===");
+        assertThat(prompt).doesNotContain("위 기존 요약에 아래 새로운 대화 내용을 통합하여");
+    }
+}

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewEvaluationServiceTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewEvaluationServiceTest.java
@@ -324,6 +324,101 @@ class InterviewEvaluationServiceTest {
     }
 
     @Test
+    @DisplayName("기능_테스트_buildEvalPrompt_history가_있으면_대화_내용이_프롬프트에_포함된다")
+    void 기능_테스트_buildEvalPrompt_history가_있으면_대화_내용이_프롬프트에_포함된다() {
+        // given
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        List<ChatMessage> history = List.of(
+                new ChatMessage("assistant", "면접관 질문입니다."),
+                new ChatMessage("user", "지원자 답변입니다.")
+        );
+
+        org.mockito.ArgumentCaptor<String> promptCaptor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.chat(promptCaptor.capture(), any(), any()))
+                .willReturn("{\"suggestFinish\":false,\"answerLevel\":\"PASS\",\"qualityHint\":\"좋습니다.\"}");
+
+        // when
+        InterviewEvaluation eval = interviewEvaluationService.evaluateWithAi(session, history, "AI 응답");
+
+        // then
+        assertThat(promptCaptor.getValue()).contains("[면접관]");
+        assertThat(promptCaptor.getValue()).contains("면접관 질문입니다.");
+        assertThat(promptCaptor.getValue()).contains("[지원자]");
+        assertThat(promptCaptor.getValue()).contains("지원자 답변입니다.");
+        assertThat(eval.answerLevel()).isEqualTo(AnswerLevel.PASS);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_parseEvaluation_readTree_예외시_catch_블록을_거쳐_fallback을_반환한다")
+    void 기능_테스트_parseEvaluation_readTree_예외시_catch_블록을_거쳐_fallback을_반환한다() {
+        // given — JSON with { and } but content causes readTree to fail
+        String malformedJson = "{this is not valid json at all}";
+
+        // when
+        InterviewEvaluation eval = interviewEvaluationService.parseEvaluation(malformedJson);
+
+        // then
+        assertThat(eval.suggestFinish()).isFalse();
+        assertThat(eval.answerLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+        assertThat(eval.qualityHint()).isEqualTo("답변이 접수되었습니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildEvalPrompt_요약이있으면_프롬프트에_포함된다")
+    void 기능_테스트_buildEvalPrompt_요약이있으면_프롬프트에_포함된다() {
+        // given
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        session.setConversationSummary("이전 면접에서 Java 기초를 다뤘습니다.");
+
+        org.mockito.ArgumentCaptor<String> promptCaptor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.chat(promptCaptor.capture(), any(), any()))
+                .willReturn("{\"suggestFinish\":false,\"answerLevel\":\"PASS\",\"qualityHint\":\"좋습니다.\"}");
+
+        // when
+        InterviewEvaluation eval = interviewEvaluationService.evaluateWithAi(session, List.of(), "AI 응답");
+
+        // then
+        assertThat(promptCaptor.getValue()).contains("=== 이전 대화 요약 (참고용) ===");
+        assertThat(promptCaptor.getValue()).contains("이전 면접에서 Java 기초를 다뤘습니다.");
+        assertThat(eval.answerLevel()).isEqualTo(AnswerLevel.PASS);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildEvalPrompt_요약이없으면_프롬프트에_미포함된다")
+    void 기능_테스트_buildEvalPrompt_요약이없으면_프롬프트에_미포함된다() {
+        // given
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        // conversationSummary is null by default
+
+        org.mockito.ArgumentCaptor<String> promptCaptor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.chat(promptCaptor.capture(), any(), any()))
+                .willReturn("{\"suggestFinish\":false,\"answerLevel\":\"NEEDS_IMPROVEMENT\",\"qualityHint\":\"힌트\"}");
+
+        // when
+        InterviewEvaluation eval = interviewEvaluationService.evaluateWithAi(session, List.of(), "AI 응답");
+
+        // then
+        assertThat(promptCaptor.getValue()).doesNotContain("=== 이전 대화 요약 (참고용) ===");
+        assertThat(eval.answerLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+    }
+
+    @Test
     @DisplayName("기능_테스트_evaluateAsync_AI_성공_후_메시지가_사라지면_catch를_거쳐_fallback이_적용된다")
     void 기능_테스트_evaluateAsync_AI_성공_후_메시지가_사라지면_catch를_거쳐_fallback이_적용된다() {
         // given

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -99,6 +99,9 @@ class InterviewServiceImplTest {
     private InterviewEvaluationService interviewEvaluationService;
 
     @Mock
+    private ConversationSummaryService conversationSummaryService;
+
+    @Mock
     private TokenEstimator tokenEstimator;
 
     @Mock
@@ -130,6 +133,16 @@ class InterviewServiceImplTest {
                                     msg.getRole() == com.interviewai.backend.interview.enums.MessageRole.AI ? "assistant" : "user",
                                     msg.getContent()))
                             .toList();
+                });
+        lenient().when(tokenEstimator.trimHistoryWithPriorityAndReport(any(), anyInt()))
+                .thenAnswer(inv -> {
+                    List<InterviewMessage> msgs = inv.getArgument(0);
+                    List<com.interviewai.backend.client.dto.ChatMessage> retained = msgs.stream()
+                            .map(msg -> new com.interviewai.backend.client.dto.ChatMessage(
+                                    msg.getRole() == com.interviewai.backend.interview.enums.MessageRole.AI ? "assistant" : "user",
+                                    msg.getContent()))
+                            .toList();
+                    return new TrimResult(retained, List.of(), false);
                 });
         lenient().when(tokenEstimator.trimHistory(any(), anyInt()))
                 .thenAnswer(inv -> inv.getArgument(0));
@@ -1754,6 +1767,805 @@ class InterviewServiceImplTest {
         assertThatThrownBy(() -> interviewService.getLatestEvaluation(userId, sessionId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("메시지");
+    }
+
+    // ----------------------------------------------------------------
+    // 커버리지 보완 테스트
+    // ----------------------------------------------------------------
+
+    @Test
+    @DisplayName("예외_테스트_startInterview_사용자가_없으면_예외가_발생한다")
+    void 예외_테스트_startInterview_사용자가_없으면_예외가_발생한다() {
+        // given
+        Long userId = 999L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.BASIC);
+        setField(request, "level", InterviewLevel.JUNIOR);
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.startInterview(userId, request))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_finishInterview_세션이_존재하지_않으면_예외가_발생한다")
+    void 예외_테스트_finishInterview_세션이_존재하지_않으면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.finishInterview(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_findSessionMessages_메시지_목록을_반환한다")
+    void 기능_테스트_findSessionMessages_메시지_목록을_반환한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        InterviewMessage msg1 = InterviewMessage.builder()
+                .session(session).role(MessageRole.AI).content("질문입니다.").build();
+        InterviewMessage msg2 = InterviewMessage.builder()
+                .session(session).role(MessageRole.USER).content("답변입니다.").build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId))
+                .willReturn(List.of(msg1, msg2));
+
+        // when
+        List<InterviewMessageResponseDto> result = interviewService.findSessionMessages(userId, sessionId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getContent()).isEqualTo("질문입니다.");
+        assertThat(result.get(1).getContent()).isEqualTo("답변입니다.");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_findSessionMessages_세션이_존재하지_않으면_예외가_발생한다")
+    void 예외_테스트_findSessionMessages_세션이_존재하지_않으면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.findSessionMessages(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_findFeedback_세션이_존재하지_않으면_예외가_발생한다")
+    void 예외_테스트_findFeedback_세션이_존재하지_않으면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.findFeedback(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("면접 세션");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_findFeedback_피드백을_정상_조회한다")
+    void 기능_테스트_findFeedback_피드백을_정상_조회한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        InterviewFeedback feedback = InterviewFeedback.builder()
+                .session(session)
+                .overallLevel(AnswerLevel.PASS)
+                .strengths("잘했습니다.")
+                .improvements("없습니다.")
+                .fullReport("훌륭합니다.")
+                .build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId))
+                .willReturn(Optional.of(session));
+        given(interviewFeedbackRepository.findBySessionId(sessionId))
+                .willReturn(Optional.of(feedback));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.findFeedback(userId, sessionId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.PASS);
+    }
+
+    @Test
+    @DisplayName("예외_테스트_validateModeRequirements_COMPANY_모드에서_문서와_github_없으면_예외가_발생한다")
+    void 예외_테스트_validateModeRequirements_COMPANY_모드에서_문서와_github_없으면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.COMPANY);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        // documentIds null, githubUrl null
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.startInterview(userId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("문서");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_CAREER_STATEMENT_문서_타입이_포함된다")
+    void 기능_테스트_startInterview_CAREER_STATEMENT_문서_타입이_포함된다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.RESUME);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L));
+
+        UserDocument careerDoc = mock(UserDocument.class);
+        when(careerDoc.getDocumentType()).thenReturn(DocumentType.CAREER_STATEMENT);
+        when(careerDoc.getParsedText()).thenReturn("경력기술서 내용입니다.");
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.RESUME).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L), userId)).willReturn(List.of(careerDoc));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+
+        // when
+        interviewService.startInterview(userId, request);
+
+        // then
+        ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
+        verify(interviewSessionRepository, times(2)).save(sessionCaptor.capture());
+        String prompt = sessionCaptor.getAllValues().get(1).getSystemPrompt();
+        assertThat(prompt).contains("=== 지원자 경력기술서 ===");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_문서_parsedText가_null이면_프롬프트에_포함되지_않는다")
+    void 기능_테스트_startInterview_문서_parsedText가_null이면_프롬프트에_포함되지_않는다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.RESUME);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L));
+
+        // parsedText=null → getDocumentType()은 호출되지 않으므로 stub 불필요
+        UserDocument doc = mock(UserDocument.class);
+        when(doc.getParsedText()).thenReturn(null);
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.RESUME).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L), userId)).willReturn(List.of(doc));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+
+        // when
+        interviewService.startInterview(userId, request);
+
+        // then
+        ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
+        verify(interviewSessionRepository, times(2)).save(sessionCaptor.capture());
+        String prompt = sessionCaptor.getAllValues().get(1).getSystemPrompt();
+        assertThat(prompt).doesNotContain("=== 지원자 이력서 ===");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_문서_텍스트_길이_초과시_절삭한다")
+    void 기능_테스트_startInterview_문서_텍스트_길이_초과시_절삭한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.RESUME);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L));
+
+        // maxDocumentLength default is 1500, create text longer than that
+        String longText = "A".repeat(2000);
+        UserDocument doc = mock(UserDocument.class);
+        when(doc.getDocumentType()).thenReturn(DocumentType.RESUME);
+        when(doc.getParsedText()).thenReturn(longText);
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.RESUME).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L), userId)).willReturn(List.of(doc));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+
+        // when
+        interviewService.startInterview(userId, request);
+
+        // then
+        ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
+        verify(interviewSessionRepository, times(2)).save(sessionCaptor.capture());
+        String prompt = sessionCaptor.getAllValues().get(1).getSystemPrompt();
+        assertThat(prompt).contains("...");
+        assertThat(prompt).doesNotContain(longText); // full text not included
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_채용공고_텍스트_길이_초과시_절삭한다")
+    void 기능_테스트_startInterview_채용공고_텍스트_길이_초과시_절삭한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.COMPANY);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L));
+        setField(request, "jobPostingUrl", "https://jobs.example.com/job");
+
+        String longJobPosting = "B".repeat(2000);
+
+        UserDocument doc = mock(UserDocument.class);
+        when(doc.getDocumentType()).thenReturn(DocumentType.RESUME);
+        when(doc.getParsedText()).thenReturn("이력서 내용");
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.COMPANY).level(InterviewLevel.JUNIOR)
+                .jobPostingContent(longJobPosting).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L), userId)).willReturn(List.of(doc));
+        given(jobCrawlerClient.crawl(any())).willReturn(longJobPosting);
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+
+        // when
+        interviewService.startInterview(userId, request);
+
+        // then
+        ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
+        verify(interviewSessionRepository, times(2)).save(sessionCaptor.capture());
+        String prompt = sessionCaptor.getAllValues().get(1).getSystemPrompt();
+        assertThat(prompt).contains("=== 채용공고 내용 ===");
+        assertThat(prompt).contains("...");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_finishInterview_토큰_초과시_buildTrimmedConversationText로_AI와_지원자_역할이_포함된다")
+    void 기능_테스트_finishInterview_토큰_초과시_buildTrimmedConversationText로_AI와_지원자_역할이_포함된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        lenient().when(tokenEstimator.estimateTokens(anyString())).thenReturn(50000);
+
+        // toChatMessages returns trimmed messages including assistant and user roles
+        List<com.interviewai.backend.client.dto.ChatMessage> trimmedMessages = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "면접관 질문"),
+                new com.interviewai.backend.client.dto.ChatMessage("user", "지원자 답변")
+        );
+        lenient().when(tokenEstimator.toChatMessages(any())).thenReturn(trimmedMessages);
+        lenient().when(tokenEstimator.trimHistory(any(), anyInt())).thenReturn(trimmedMessages);
+
+        ArgumentCaptor<String> conversationCaptor = ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.generateFeedback(any(), conversationCaptor.capture()))
+                .willReturn("{\"overallLevel\":\"PASS\",\"strengths\":\"좋음\",\"improvements\":\"없음\",\"fullReport\":\"리포트\"}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        interviewService.finishInterview(userId, sessionId);
+
+        // then
+        String capturedConversation = conversationCaptor.getValue();
+        assertThat(capturedConversation).contains("[면접관]");
+        assertThat(capturedConversation).contains("면접관 질문");
+        assertThat(capturedConversation).contains("[지원자]");
+        assertThat(capturedConversation).contains("지원자 답변");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_finishInterview_parseFeedbackAndSave_JSON_예외시_catch_블록을_거친다")
+    void 기능_테스트_finishInterview_parseFeedbackAndSave_JSON_예외시_catch_블록을_거친다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        // Return JSON with { but malformed inside to trigger readTree exception
+        given(claudeAiClient.generateFeedback(any(), any())).willReturn("{invalid json:}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then — falls back to default values
+        assertThat(result).isNotNull();
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_joinSafely_예외시_graceful_degradation으로_null을_반환한다")
+    void 기능_테스트_startInterview_joinSafely_예외시_graceful_degradation으로_null을_반환한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.COMPANY);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of(1L));
+        setField(request, "jobPostingUrl", "https://jobs.example.com/job");
+
+        UserDocument doc = mock(UserDocument.class);
+        when(doc.getDocumentType()).thenReturn(DocumentType.RESUME);
+        when(doc.getParsedText()).thenReturn("이력서 내용");
+
+        // crawl throws exception → joinSafely catches it → returns null
+        given(jobCrawlerClient.crawl(any())).willThrow(new RuntimeException("크롤 실패"));
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.COMPANY).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userDocumentRepository.findAllByIdInAndUserId(List.of(1L), userId)).willReturn(List.of(doc));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+        given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
+
+        // when — should not throw, graceful degradation
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_documentIds가_빈_리스트이면_문서를_조회하지_않는다")
+    void 기능_테스트_startInterview_documentIds가_빈_리스트이면_문서를_조회하지_않는다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.BASIC);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of()); // empty list
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+
+        // when
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        verify(userDocumentRepository, org.mockito.Mockito.never()).findAllByIdInAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("예외_테스트_validateModeRequirements_RESUME_모드에서_빈_documentIds이면_예외가_발생한다")
+    void 예외_테스트_validateModeRequirements_RESUME_모드에서_빈_documentIds이면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.RESUME);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of()); // empty list, not null
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.startInterview(userId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("문서");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildSendMessageSystemPrompt_요약이_blank이면_시스템프롬프트에_미포함된다")
+    void 기능_테스트_buildSendMessageSystemPrompt_요약이_blank이면_시스템프롬프트에_미포함된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+        session.setConversationSummary("   "); // blank summary
+
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of();
+        TrimResult noTrimResult = new TrimResult(retainedList, List.of(), false);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        org.mockito.Mockito.doReturn(noTrimResult)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+
+        ArgumentCaptor<String> systemPromptCaptor = ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.chat(systemPromptCaptor.capture(), any(), any())).willReturn("AI 응답");
+
+        InterviewMessage savedAiMsg = mock(InterviewMessage.class);
+        given(savedAiMsg.getId()).willReturn(302L);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null, savedAiMsg);
+
+        // when
+        interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        assertThat(systemPromptCaptor.getValue()).doesNotContain("=== 이전 대화 요약 ===");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_finishInterview_parseFeedbackAndSave_JSON_필드_없을때_기본값을_사용한다")
+    void 기능_테스트_finishInterview_parseFeedbackAndSave_JSON_필드_없을때_기본값을_사용한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        // JSON with no overallLevel, strengths, improvements, fullReport fields
+        given(claudeAiClient.generateFeedback(any(), any())).willReturn("{}");
+        given(interviewFeedbackRepository.save(any(InterviewFeedback.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        InterviewFeedbackResponseDto result = interviewService.finishInterview(userId, sessionId);
+
+        // then
+        assertThat(result.getOverallLevel()).isEqualTo(AnswerLevel.NEEDS_IMPROVEMENT);
+        assertThat(result.getStrengths()).isEqualTo("분석 중...");
+        assertThat(result.getImprovements()).isEqualTo("분석 중...");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_validateModeRequirements_COMPANY_모드에서_빈_documentIds이면_예외가_발생한다")
+    void 예외_테스트_validateModeRequirements_COMPANY_모드에서_빈_documentIds이면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.COMPANY);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "documentIds", List.of()); // empty, not null
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> interviewService.startInterview(userId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("문서");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_summaryDisabled이면_요약생성을_호출하지않는다")
+    void 기능_테스트_streamMessage_summaryDisabled이면_요약생성을_호출하지않는다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        InterviewMessage priorMsg = InterviewMessage.builder()
+                .session(session).role(MessageRole.AI).content("질문입니다.").build();
+
+        List<InterviewMessage> trimmedList = List.of(priorMsg);
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "질문입니다."));
+        TrimResult trimResultWithTrimming = new TrimResult(retainedList, trimmedList, true);
+
+        InterviewProperties.Prompt prompt = new InterviewProperties.Prompt();
+        prompt.setSummaryEnabled(false);
+        given(interviewProperties.getPrompt()).willReturn(prompt);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of(priorMsg));
+        org.mockito.Mockito.doReturn(trimResultWithTrimming)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        lenient().when(claudeAiClient.streamChat(any(), any(), any()))
+                .thenReturn(reactor.core.publisher.Flux.just("토큰"));
+
+        // when
+        interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        verify(conversationSummaryService, org.mockito.Mockito.never()).generateSummaryAsync(any(), any());
+    }
+
+    // ----------------------------------------------------------------
+    // sendMessage + trimming/summary 테스트
+    // ----------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_sendMessage_trimming발생시_요약생성을_비동기호출한다")
+    void 기능_테스트_sendMessage_trimming발생시_요약생성을_비동기호출한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        InterviewMessage priorMsg = InterviewMessage.builder()
+                .session(session).role(MessageRole.AI).content("질문입니다.").build();
+        List<InterviewMessage> priorMessages = List.of(priorMsg);
+
+        List<InterviewMessage> trimmedList = List.of(priorMsg);
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "질문입니다."));
+        TrimResult trimResultWithTrimming = new TrimResult(retainedList, trimmedList, true);
+
+        InterviewProperties.Prompt prompt = new InterviewProperties.Prompt();
+        prompt.setSummaryEnabled(true);
+        given(interviewProperties.getPrompt()).willReturn(prompt);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(priorMessages);
+        org.mockito.Mockito.doReturn(trimResultWithTrimming)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("AI 응답");
+        InterviewMessage savedAiMsg = mock(InterviewMessage.class);
+        given(savedAiMsg.getId()).willReturn(200L);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null, savedAiMsg);
+
+        // when
+        interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        verify(conversationSummaryService).generateSummaryAsync(eq(sessionId), eq(trimmedList));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_sendMessage_trimming미발생시_요약생성을_호출하지않는다")
+    void 기능_테스트_sendMessage_trimming미발생시_요약생성을_호출하지않는다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        InterviewMessage priorMsg = InterviewMessage.builder()
+                .session(session).role(MessageRole.AI).content("질문입니다.").build();
+        List<InterviewMessage> priorMessages = List.of(priorMsg);
+
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "질문입니다."));
+        TrimResult noTrimResult = new TrimResult(retainedList, List.of(), false);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(priorMessages);
+        org.mockito.Mockito.doReturn(noTrimResult)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("AI 응답");
+        InterviewMessage savedAiMsg = mock(InterviewMessage.class);
+        given(savedAiMsg.getId()).willReturn(200L);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null, savedAiMsg);
+
+        // when
+        interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        verify(conversationSummaryService, org.mockito.Mockito.never())
+                .generateSummaryAsync(any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_sendMessage_summaryDisabled이면_요약생성을_호출하지않는다")
+    void 기능_테스트_sendMessage_summaryDisabled이면_요약생성을_호출하지않는다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        InterviewMessage priorMsg = InterviewMessage.builder()
+                .session(session).role(MessageRole.AI).content("질문입니다.").build();
+        List<InterviewMessage> priorMessages = List.of(priorMsg);
+
+        List<InterviewMessage> trimmedList = List.of(priorMsg);
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "질문입니다."));
+        TrimResult trimResultWithTrimming = new TrimResult(retainedList, trimmedList, true);
+
+        // summaryEnabled = false
+        InterviewProperties.Prompt prompt = new InterviewProperties.Prompt();
+        prompt.setSummaryEnabled(false);
+        given(interviewProperties.getPrompt()).willReturn(prompt);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(priorMessages);
+        org.mockito.Mockito.doReturn(trimResultWithTrimming)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        given(claudeAiClient.chat(any(), any(), any())).willReturn("AI 응답");
+        InterviewMessage savedAiMsg = mock(InterviewMessage.class);
+        given(savedAiMsg.getId()).willReturn(200L);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null, savedAiMsg);
+
+        // when
+        interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        verify(conversationSummaryService, org.mockito.Mockito.never())
+                .generateSummaryAsync(any(), any());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamMessage_trimming발생시_요약생성을_비동기호출한다")
+    void 기능_테스트_streamMessage_trimming발생시_요약생성을_비동기호출한다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+
+        InterviewMessage priorMsg = InterviewMessage.builder()
+                .session(session).role(MessageRole.AI).content("질문입니다.").build();
+        List<InterviewMessage> priorMessages = List.of(priorMsg);
+
+        List<InterviewMessage> trimmedList = List.of(priorMsg);
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "질문입니다."));
+        TrimResult trimResultWithTrimming = new TrimResult(retainedList, trimmedList, true);
+
+        InterviewProperties.Prompt prompt = new InterviewProperties.Prompt();
+        prompt.setSummaryEnabled(true);
+        given(interviewProperties.getPrompt()).willReturn(prompt);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(priorMessages);
+        org.mockito.Mockito.doReturn(trimResultWithTrimming)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+        lenient().when(claudeAiClient.streamChat(any(), any(), any()))
+                .thenReturn(reactor.core.publisher.Flux.just("토큰"));
+
+        // when
+        interviewService.streamMessage(userId, sessionId, request);
+
+        // then
+        verify(conversationSummaryService).generateSummaryAsync(eq(sessionId), eq(trimmedList));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildSendMessageSystemPrompt_요약이있으면_시스템프롬프트에_포함된다")
+    void 기능_테스트_buildSendMessageSystemPrompt_요약이있으면_시스템프롬프트에_포함된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        session.setConversationSummary("이전 면접에서 Java 기초를 다뤘습니다.");
+
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of();
+        TrimResult noTrimResult = new TrimResult(retainedList, List.of(), false);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        org.mockito.Mockito.doReturn(noTrimResult)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+
+        ArgumentCaptor<String> systemPromptCaptor = ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.chat(systemPromptCaptor.capture(), any(), any())).willReturn("AI 응답");
+
+        InterviewMessage savedAiMsg = mock(InterviewMessage.class);
+        given(savedAiMsg.getId()).willReturn(300L);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null, savedAiMsg);
+
+        // when
+        interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        String capturedPrompt = systemPromptCaptor.getValue();
+        assertThat(capturedPrompt).contains("=== 이전 대화 요약 ===");
+        assertThat(capturedPrompt).contains("이전 면접에서 Java 기초를 다뤘습니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_buildSendMessageSystemPrompt_요약이없으면_시스템프롬프트에_미포함된다")
+    void 기능_테스트_buildSendMessageSystemPrompt_요약이없으면_시스템프롬프트에_미포함된다() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        InterviewSendMessageRequestDto request = new InterviewSendMessageRequestDto();
+        setField(request, "content", "답변입니다.");
+
+        InterviewSession session = InterviewSession.builder()
+                .user(testUser)
+                .mode(InterviewMode.BASIC)
+                .level(InterviewLevel.JUNIOR)
+                .build();
+        // conversationSummary is null by default
+
+        List<com.interviewai.backend.client.dto.ChatMessage> retainedList = List.of();
+        TrimResult noTrimResult = new TrimResult(retainedList, List.of(), false);
+
+        given(interviewSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(interviewMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).willReturn(List.of());
+        org.mockito.Mockito.doReturn(noTrimResult)
+                .when(tokenEstimator).trimHistoryWithPriorityAndReport(any(), anyInt());
+        given(interviewSessionDocumentRepository.findBySessionId(sessionId)).willReturn(List.of());
+
+        ArgumentCaptor<String> systemPromptCaptor = ArgumentCaptor.forClass(String.class);
+        given(claudeAiClient.chat(systemPromptCaptor.capture(), any(), any())).willReturn("AI 응답");
+
+        InterviewMessage savedAiMsg = mock(InterviewMessage.class);
+        given(savedAiMsg.getId()).willReturn(301L);
+        given(interviewMessageRepository.save(any(InterviewMessage.class))).willReturn(null, savedAiMsg);
+
+        // when
+        interviewService.sendMessage(userId, sessionId, request);
+
+        // then
+        String capturedPrompt = systemPromptCaptor.getValue();
+        assertThat(capturedPrompt).doesNotContain("=== 이전 대화 요약 ===");
     }
 
     private void setField(Object target, String fieldName, Object value) {

--- a/src/test/java/com/interviewai/backend/interview/service/TokenEstimatorTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/TokenEstimatorTest.java
@@ -173,6 +173,141 @@ class TokenEstimatorTest {
         assertThat(result.get(1).content()).isEqualTo("답변입니다");
     }
 
+    // ----------------------------------------------------------------
+    // trimHistoryWithPriorityAndReport 테스트
+    // ----------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_trimHistoryWithPriorityAndReport_budget충분하면_wasTrimmed가_false이고_trimmed가_비어있다")
+    void 기능_테스트_trimHistoryWithPriorityAndReport_budget충분하면_wasTrimmed가_false이고_trimmed가_비어있다() {
+        InterviewSession session = mock(InterviewSession.class);
+        List<InterviewMessage> messages = List.of(
+                createMessage(session, MessageRole.AI, "aaa", null, 1),
+                createMessage(session, MessageRole.USER, "bbb", AnswerLevel.PASS, 2)
+        );
+
+        TrimResult result = tokenEstimator.trimHistoryWithPriorityAndReport(messages, 10000);
+
+        assertThat(result.wasTrimmed()).isFalse();
+        assertThat(result.trimmed()).isEmpty();
+        assertThat(result.retained()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_trimHistoryWithPriorityAndReport_budget초과시_wasTrimmed가_true이고_trimmed에_잘린_메시지가_포함된다")
+    void 기능_테스트_trimHistoryWithPriorityAndReport_budget초과시_wasTrimmed가_true이고_trimmed에_잘린_메시지가_포함된다() {
+        InterviewSession session = mock(InterviewSession.class);
+        List<InterviewMessage> messages = List.of(
+                createMessage(session, MessageRole.AI, "aaa", null, 1),          // 첫 메시지 (1 토큰)
+                createMessage(session, MessageRole.USER, "bbb", AnswerLevel.PASS, 2), // PASS (1 토큰)
+                createMessage(session, MessageRole.AI, "ccc", null, 3),
+                createMessage(session, MessageRole.USER, "ddd", AnswerLevel.PASS, 4)
+        );
+
+        // budget=2: 첫 메시지(1) + 남은 1 → 최근 1개 normal 포함 시도
+        TrimResult result = tokenEstimator.trimHistoryWithPriorityAndReport(messages, 2);
+
+        assertThat(result.wasTrimmed()).isTrue();
+        assertThat(result.trimmed()).isNotEmpty();
+        assertThat(result.retained()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_trimHistoryWithPriorityAndReport_빈_메시지이면_빈_결과를_반환한다")
+    void 기능_테스트_trimHistoryWithPriorityAndReport_빈_메시지이면_빈_결과를_반환한다() {
+        TrimResult result = tokenEstimator.trimHistoryWithPriorityAndReport(List.of(), 100);
+
+        assertThat(result.wasTrimmed()).isFalse();
+        assertThat(result.trimmed()).isEmpty();
+        assertThat(result.retained()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_trimHistoryWithPriorityAndReport_budget이_첫메시지보다_작으면_나머지가_모두_trimmed에_포함된다")
+    void 기능_테스트_trimHistoryWithPriorityAndReport_budget이_첫메시지보다_작으면_나머지가_모두_trimmed에_포함된다() {
+        InterviewSession session = mock(InterviewSession.class);
+        List<InterviewMessage> messages = List.of(
+                createMessage(session, MessageRole.AI, "abcdefghijklmno", null, 1), // 5 토큰
+                createMessage(session, MessageRole.USER, "bbb", AnswerLevel.PASS, 2),
+                createMessage(session, MessageRole.AI, "ccc", null, 3)
+        );
+
+        // budget=1: 첫 메시지(5토큰) > budget → remainingBudget <= 0
+        TrimResult result = tokenEstimator.trimHistoryWithPriorityAndReport(messages, 1);
+
+        assertThat(result.wasTrimmed()).isTrue();
+        // 첫 메시지만 retained, 나머지 2개는 trimmed
+        assertThat(result.retained()).hasSize(1);
+        assertThat(result.retained().get(0).content()).isEqualTo("abcdefghijklmno");
+        assertThat(result.trimmed()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_trimHistory_budget과_정확히_같은_크기면_전부_반환한다")
+    void 기능_테스트_trimHistory_budget과_정확히_같은_크기면_전부_반환한다() {
+        // charsPerToken=3, so "aaa"=1토큰, "bbb"=1토큰, "ccc"=1토큰 → total 3 tokens
+        List<ChatMessage> history = List.of(
+                new ChatMessage("assistant", "aaa"),
+                new ChatMessage("user", "bbb"),
+                new ChatMessage("assistant", "ccc")
+        );
+        List<ChatMessage> result = tokenEstimator.trimHistory(history, 3);
+        assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_trimHistory_첫_메시지만_있을때_budget_초과시_첫_메시지만_반환한다")
+    void 기능_테스트_trimHistory_첫_메시지만_있을때_budget_초과시_첫_메시지만_반환한다() {
+        // only one message, totalTokens > maxTokens
+        // first = history.get(0) → firstTokens=2, remainingBudget=maxTokens-2=-1 ≤ 0
+        // → return List.of(first)
+        List<ChatMessage> history = List.of(
+                new ChatMessage("assistant", "abcdef") // 2 tokens
+        );
+        // budget=1 < firstTokens=2
+        List<ChatMessage> result = tokenEstimator.trimHistory(history, 1);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).content()).isEqualTo("abcdef");
+    }
+
+
+    @Test
+    @DisplayName("기능_테스트_trimHistoryWithPriorityAndReport_STUDY_REQUIRED가_budget을_넘으면_normal도_일부만_포함된다")
+    void 기능_테스트_trimHistoryWithPriorityAndReport_STUDY_REQUIRED가_budget을_넘으면_normal도_일부만_포함된다() {
+        InterviewSession session = mock(InterviewSession.class);
+        // charsPerToken=3: "aaa"=1토큰, "bbbbbbbbbbbbb"=4토큰(13/3=4), "ccc"=1토큰
+        List<InterviewMessage> messages = List.of(
+                createMessage(session, MessageRole.AI, "aaa", null, 1),                     // first (1 토큰)
+                createMessage(session, MessageRole.USER, "bbbbbbbbbbbbb", AnswerLevel.STUDY_REQUIRED, 2), // 4 토큰 priority
+                createMessage(session, MessageRole.AI, "ccc", null, 3),
+                createMessage(session, MessageRole.USER, "ddd", AnswerLevel.PASS, 4)
+        );
+        // budget=3: first(1) + remaining=2 → STUDY_REQUIRED(4) > 2 → break from priority loop
+        // normal messages added from end: "ddd"(1) ≤ 2 → include; "ccc"(1) ≤ 1 → include
+        TrimResult result = tokenEstimator.trimHistoryWithPriorityAndReport(messages, 3);
+
+        assertThat(result.wasTrimmed()).isTrue();
+        // STUDY_REQUIRED가 budget을 초과하여 포함되지 않음
+        assertThat(result.retained().stream().noneMatch(m -> m.content().equals("bbbbbbbbbbbbb"))).isTrue();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_trimHistoryWithPriority가_trimHistoryWithPriorityAndReport의_retained를_반환한다")
+    void 기능_테스트_trimHistoryWithPriority가_trimHistoryWithPriorityAndReport의_retained를_반환한다() {
+        InterviewSession session = mock(InterviewSession.class);
+        List<InterviewMessage> messages = List.of(
+                createMessage(session, MessageRole.AI, "aaa", null, 1),
+                createMessage(session, MessageRole.USER, "bbb", AnswerLevel.PASS, 2)
+        );
+
+        List<com.interviewai.backend.client.dto.ChatMessage> retained =
+                tokenEstimator.trimHistoryWithPriority(messages, 10000);
+        TrimResult report =
+                tokenEstimator.trimHistoryWithPriorityAndReport(messages, 10000);
+
+        assertThat(retained).isEqualTo(report.retained());
+    }
+
     private InterviewMessage createMessage(InterviewSession session, MessageRole role,
                                            String content, AnswerLevel answerLevel, int minuteOffset) {
         InterviewMessage msg = InterviewMessage.builder()


### PR DESCRIPTION
## Summary
- trimming 발생 시 잘려나간 메시지를 AI로 요약하여 `InterviewSession.conversationSummary`에 비동기 저장
- 시스템 프롬프트 및 평가 프롬프트에 요약을 삽입하여 "이전 대화 요약 + 최근 원문" 구조로 맥락 보존
- `TrimResult` record 도입으로 잘린 메시지 추적, `ConversationSummaryService`로 비동기 요약 생성 (`summaryExecutor` 별도 스레드풀)

## Test plan
- [x] `./gradlew test` 전체 통과
- [x] `./gradlew build` 성공
- [ ] 로컬에서 면접 20턴 이상 진행하여 trimming 발생 후 `conversation_summary` 컬럼에 요약 저장 확인
- [ ] 요약이 시스템 프롬프트에 포함되어 AI가 이전 주제를 기억하는지 확인
- [ ] 응답 시간이 요약 생성으로 인해 증가하지 않는지 확인 (비동기)
- [ ] 면접 종료 피드백이 정상 생성되는지 확인

Closes #62