### PR TITLE
이력서 스마트 잘라내기 — 섹션 인식 + JUNIOR/SENIOR 레벨별 우선순위

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 .gradle
 .claude/.review-passed
 build/
+bin/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/src/main/java/com/interviewai/backend/document/controller/dto/DocumentUploadResponseDto.java
+++ b/src/main/java/com/interviewai/backend/document/controller/dto/DocumentUploadResponseDto.java
@@ -14,13 +14,20 @@ public class DocumentUploadResponseDto {
     private Long id;
     private DocumentType documentType;
     private String originalFileName;
+    private int parsedTextLength;
+    private int maxUsableLength;
+    private boolean willBeTruncated;
     private LocalDateTime createdAt;
 
-    public static DocumentUploadResponseDto from(UserDocument document) {
+    public static DocumentUploadResponseDto from(UserDocument document, int maxDocumentLength) {
+        int textLength = document.getParsedText() != null ? document.getParsedText().length() : 0;
         return DocumentUploadResponseDto.builder()
                 .id(document.getId())
                 .documentType(document.getDocumentType())
                 .originalFileName(document.getOriginalFileName())
+                .parsedTextLength(textLength)
+                .maxUsableLength(maxDocumentLength)
+                .willBeTruncated(textLength > maxDocumentLength)
                 .createdAt(document.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/interviewai/backend/document/enums/DocumentErrorCode.java
+++ b/src/main/java/com/interviewai/backend/document/enums/DocumentErrorCode.java
@@ -12,7 +12,8 @@ public enum DocumentErrorCode implements ErrorCode {
     DOCUMENT_NOT_FOUND("D001", "문서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     UNSUPPORTED_FILE_TYPE("D002", "지원하지 않는 파일 형식입니다. PDF 파일만 허용됩니다.", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_FAILED("D003", "파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    FILE_PARSE_FAILED("D004", "파일 파싱에 실패했습니다.", HttpStatus.BAD_REQUEST);
+    FILE_PARSE_FAILED("D004", "파일 파싱에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    IMAGE_PDF_NOT_SUPPORTED("D005", "이미지 기반 PDF는 텍스트 추출이 불가합니다. 텍스트 기반 PDF를 업로드해주세요.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/document/service/DocumentServiceImpl.java
@@ -10,6 +10,7 @@ import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.document.repository.UserDocumentRepository;
 import com.interviewai.backend.user.enums.UserErrorCode;
 import com.interviewai.backend.user.model.User;
+import com.interviewai.backend.global.config.InterviewProperties;
 import com.interviewai.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class DocumentServiceImpl implements DocumentService {
     private final UserDocumentRepository userDocumentRepository;
     private final UserRepository userRepository;
     private final PdfParserClient pdfParserClient;
+    private final InterviewProperties interviewProperties;
 
     @Override
     @Transactional
@@ -46,6 +48,10 @@ public class DocumentServiceImpl implements DocumentService {
             throw new BusinessException(DocumentErrorCode.FILE_PARSE_FAILED);
         }
 
+        if (parsedText.length() < 50) {
+            throw new BusinessException(DocumentErrorCode.IMAGE_PDF_NOT_SUPPORTED);
+        }
+
         UserDocument document = UserDocument.builder()
                 .user(user)
                 .documentType(documentType)
@@ -53,7 +59,10 @@ public class DocumentServiceImpl implements DocumentService {
                 .parsedText(parsedText)
                 .build();
 
-        return DocumentUploadResponseDto.from(userDocumentRepository.save(document));
+        return DocumentUploadResponseDto.from(
+                userDocumentRepository.save(document),
+                interviewProperties.getPrompt().getMaxDocumentLength()
+        );
     }
 
     @Override

--- a/src/main/java/com/interviewai/backend/global/config/InterviewProperties.java
+++ b/src/main/java/com/interviewai/backend/global/config/InterviewProperties.java
@@ -17,7 +17,7 @@ public class InterviewProperties {
     @Getter
     @Setter
     public static class Prompt {
-        private int maxDocumentLength = 1500;
+        private int maxDocumentLength = 5000;
         private int maxJobPostingLength = 1500;
         private int maxHistoryTokens = 8000;
         private int maxEvalHistoryTokens = 4000;

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/DocumentTruncationInfo.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/DocumentTruncationInfo.java
@@ -1,0 +1,14 @@
+package com.interviewai.backend.interview.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DocumentTruncationInfo {
+
+    private String fileName;
+    private int originalLength;
+    private int usedLength;
+    private boolean truncated;
+}

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartResponseDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -18,15 +19,18 @@ public class InterviewStartResponseDto {
     private InterviewLevel level;
     private InterviewStatus status;
     private String firstQuestion;
+    private List<DocumentTruncationInfo> documentTruncations;
     private LocalDateTime createdAt;
 
-    public static InterviewStartResponseDto of(InterviewSession session, String firstQuestion) {
+    public static InterviewStartResponseDto of(InterviewSession session, String firstQuestion,
+                                                List<DocumentTruncationInfo> documentTruncations) {
         return InterviewStartResponseDto.builder()
                 .sessionId(session.getId())
                 .mode(session.getMode())
                 .level(session.getLevel())
                 .status(session.getStatus())
                 .firstQuestion(firstQuestion)
+                .documentTruncations(documentTruncations)
                 .createdAt(session.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -6,6 +6,7 @@ import com.interviewai.backend.client.JobCrawlerClient;
 import com.interviewai.backend.client.dto.ChatMessage;
 import com.interviewai.backend.global.common.exception.BusinessException;
 import com.interviewai.backend.global.config.InterviewProperties;
+import com.interviewai.backend.document.enums.DocumentType;
 import com.interviewai.backend.document.model.UserDocument;
 import com.interviewai.backend.document.repository.UserDocumentRepository;
 import com.interviewai.backend.interview.controller.dto.*;
@@ -61,6 +62,7 @@ public class InterviewServiceImpl implements InterviewService {
     private final InterviewEvaluationService interviewEvaluationService;
     private final ConversationSummaryService conversationSummaryService;
     private final TokenEstimator tokenEstimator;
+    private final ResumeTextSummarizer resumeTextSummarizer;
     private final InterviewProperties interviewProperties;
 
     @Override
@@ -110,11 +112,12 @@ public class InterviewServiceImpl implements InterviewService {
             );
         }
 
+        List<DocumentTruncationInfo> truncations = buildDocumentTruncations(documents);
         String systemPrompt = buildSystemPrompt(session, documents, jobPostingContent, githubInfo);
         session.setSystemPrompt(systemPrompt);
         interviewSessionRepository.save(session);
 
-        return InterviewStartResponseDto.of(session, null);
+        return InterviewStartResponseDto.of(session, null, truncations);
     }
 
     @Override
@@ -439,8 +442,13 @@ public class InterviewServiceImpl implements InterviewService {
             };
             prompt.append("\n=== 지원자 ").append(docLabel).append(" ===\n");
             String parsedText = doc.getParsedText();
-            if (parsedText.length() > interviewProperties.getPrompt().getMaxDocumentLength()) {
-                parsedText = parsedText.substring(0, interviewProperties.getPrompt().getMaxDocumentLength()) + "...";
+            int maxLen = interviewProperties.getPrompt().getMaxDocumentLength();
+            if (parsedText.length() > maxLen) {
+                if (doc.getDocumentType() == DocumentType.RESUME) {
+                    parsedText = resumeTextSummarizer.summarize(parsedText, maxLen, session.getLevel());
+                } else {
+                    parsedText = parsedText.substring(0, maxLen) + "...";
+                }
             }
             prompt.append(parsedText).append("\n");
         }
@@ -460,6 +468,22 @@ public class InterviewServiceImpl implements InterviewService {
         }
 
         return prompt.toString();
+    }
+
+    private List<DocumentTruncationInfo> buildDocumentTruncations(List<UserDocument> documents) {
+        int maxLen = interviewProperties.getPrompt().getMaxDocumentLength();
+        return documents.stream()
+                .filter(doc -> doc.getParsedText() != null)
+                .map(doc -> {
+                    int originalLength = doc.getParsedText().length();
+                    return DocumentTruncationInfo.builder()
+                            .fileName(doc.getOriginalFileName())
+                            .originalLength(originalLength)
+                            .usedLength(Math.min(originalLength, maxLen))
+                            .truncated(originalLength > maxLen)
+                            .build();
+                })
+                .toList();
     }
 
     private String buildSendMessageSystemPrompt(InterviewSession session, List<UserDocument> documents,

--- a/src/main/java/com/interviewai/backend/interview/service/ResumeTextSummarizer.java
+++ b/src/main/java/com/interviewai/backend/interview/service/ResumeTextSummarizer.java
@@ -35,25 +35,25 @@ public class ResumeTextSummarizer {
                     + "|학력\\s{0,5}(?:사항)?|education|academic"
                     + "|연락처|contact|인적\\s{0,5}사항|personal\\s{0,5}info)"
                     + "[\\s#=\\-*|】:]{0,20}$",
-            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
+            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE | Pattern.MULTILINE
     );
 
     private static final Pattern SKILLS_PATTERN = Pattern.compile(
-            "기술\\s*스택|skills?|tech(?:nical)?\\s*(?:stack|skills?)", Pattern.CASE_INSENSITIVE);
+            "기술\\s*스택|skills?|tech(?:nical)?\\s*(?:stack|skills?)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern PROJECTS_PATTERN = Pattern.compile(
-            "프로젝트|projects?", Pattern.CASE_INSENSITIVE);
+            "프로젝트|projects?", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern EXPERIENCE_PATTERN = Pattern.compile(
-            "경력|work\\s*experience|experience|career", Pattern.CASE_INSENSITIVE);
+            "경력|work\\s*experience|experience|career", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern EDUCATION_PATTERN = Pattern.compile(
-            "학력|education|academic", Pattern.CASE_INSENSITIVE);
+            "학력|education|academic", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern CERTIFICATIONS_PATTERN = Pattern.compile(
-            "자격|certifications?|licenses?", Pattern.CASE_INSENSITIVE);
+            "자격|certifications?|licenses?", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern AWARDS_PATTERN = Pattern.compile(
-            "수상|awards?|honors?", Pattern.CASE_INSENSITIVE);
+            "수상|awards?|honors?", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern SUMMARY_PATTERN = Pattern.compile(
-            "자기\\s*소개|summary|objective|about\\s*me|소개", Pattern.CASE_INSENSITIVE);
+            "자기\\s*소개|summary|objective|about\\s*me|소개", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     private static final Pattern CONTACT_PATTERN = Pattern.compile(
-            "연락처|contact|인적\\s*사항|personal\\s*info", Pattern.CASE_INSENSITIVE);
+            "연락처|contact|인적\\s*사항|personal\\s*info", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
     public String summarize(String parsedText, int maxLength, InterviewLevel level) {
         if (parsedText == null || parsedText.isEmpty()) {

--- a/src/main/java/com/interviewai/backend/interview/service/ResumeTextSummarizer.java
+++ b/src/main/java/com/interviewai/backend/interview/service/ResumeTextSummarizer.java
@@ -25,16 +25,16 @@ public class ResumeTextSummarizer {
     }
 
     private static final Pattern SECTION_HEADER = Pattern.compile(
-            "^[\\s#=\\-*|【]*(?:\\d+\\.?\\s*)?"
-                    + "(?:기술\\s*스택|skills?|tech(?:nical)?\\s*(?:stack|skills?)"
-                    + "|프로젝트\\s*(?:경험|이력)?|projects?"
-                    + "|경력\\s*(?:사항|기술서)?|work\\s*experience|experience|career"
-                    + "|자격\\s*(?:증|사항)|certifications?|licenses?"
-                    + "|수상\\s*(?:경력|내역)?|awards?|honors?"
-                    + "|자기\\s*소개|summary|objective|about\\s*me|소개"
-                    + "|학력\\s*(?:사항)?|education|academic"
-                    + "|연락처|contact|인적\\s*사항|personal\\s*info)"
-                    + "[\\s#=\\-*|】:]*$",
+            "^[\\s#=\\-*|【]{0,20}(?:\\d+\\.?\\s{0,5})?"
+                    + "(?:기술\\s{0,5}스택|skills?|tech(?:nical)?\\s{0,5}(?:stack|skills?)"
+                    + "|프로젝트\\s{0,5}(?:경험|이력)?|projects?"
+                    + "|경력\\s{0,5}(?:사항|기술서)?|work\\s{0,5}experience|experience|career"
+                    + "|자격\\s{0,5}(?:증|사항)|certifications?|licenses?"
+                    + "|수상\\s{0,5}(?:경력|내역)?|awards?|honors?"
+                    + "|자기\\s{0,5}소개|summary|objective|about\\s{0,5}me|소개"
+                    + "|학력\\s{0,5}(?:사항)?|education|academic"
+                    + "|연락처|contact|인적\\s{0,5}사항|personal\\s{0,5}info)"
+                    + "[\\s#=\\-*|】:]{0,20}$",
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
     );
 

--- a/src/main/java/com/interviewai/backend/interview/service/ResumeTextSummarizer.java
+++ b/src/main/java/com/interviewai/backend/interview/service/ResumeTextSummarizer.java
@@ -1,0 +1,217 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.interview.enums.InterviewLevel;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class ResumeTextSummarizer {
+
+    enum SectionPriority { P1, P2, P3 }
+
+    record ResumeSection(int index, String header, String body, SectionPriority priority) {
+        ResumeSection withPriority(SectionPriority newPriority) {
+            return new ResumeSection(index, header, body, newPriority);
+        }
+
+        int length() {
+            return header.length() + body.length();
+        }
+    }
+
+    private static final Pattern SECTION_HEADER = Pattern.compile(
+            "^[\\s#=\\-*|【]*(?:\\d+\\.?\\s*)?"
+                    + "(?:기술\\s*스택|skills?|tech(?:nical)?\\s*(?:stack|skills?)"
+                    + "|프로젝트\\s*(?:경험|이력)?|projects?"
+                    + "|경력\\s*(?:사항|기술서)?|work\\s*experience|experience|career"
+                    + "|자격\\s*(?:증|사항)|certifications?|licenses?"
+                    + "|수상\\s*(?:경력|내역)?|awards?|honors?"
+                    + "|자기\\s*소개|summary|objective|about\\s*me|소개"
+                    + "|학력\\s*(?:사항)?|education|academic"
+                    + "|연락처|contact|인적\\s*사항|personal\\s*info)"
+                    + "[\\s#=\\-*|】:]*$",
+            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
+    );
+
+    private static final Pattern SKILLS_PATTERN = Pattern.compile(
+            "기술\\s*스택|skills?|tech(?:nical)?\\s*(?:stack|skills?)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PROJECTS_PATTERN = Pattern.compile(
+            "프로젝트|projects?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern EXPERIENCE_PATTERN = Pattern.compile(
+            "경력|work\\s*experience|experience|career", Pattern.CASE_INSENSITIVE);
+    private static final Pattern EDUCATION_PATTERN = Pattern.compile(
+            "학력|education|academic", Pattern.CASE_INSENSITIVE);
+    private static final Pattern CERTIFICATIONS_PATTERN = Pattern.compile(
+            "자격|certifications?|licenses?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AWARDS_PATTERN = Pattern.compile(
+            "수상|awards?|honors?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SUMMARY_PATTERN = Pattern.compile(
+            "자기\\s*소개|summary|objective|about\\s*me|소개", Pattern.CASE_INSENSITIVE);
+    private static final Pattern CONTACT_PATTERN = Pattern.compile(
+            "연락처|contact|인적\\s*사항|personal\\s*info", Pattern.CASE_INSENSITIVE);
+
+    public String summarize(String parsedText, int maxLength, InterviewLevel level) {
+        if (parsedText == null || parsedText.isEmpty()) {
+            return "";
+        }
+        if (parsedText.length() <= maxLength) {
+            return parsedText;
+        }
+
+        List<ResumeSection> sections = splitIntoSections(parsedText);
+
+        if (sections.size() < 2) {
+            return parsedText.substring(0, maxLength) + "...";
+        }
+
+        List<ResumeSection> classified = sections.stream()
+                .map(s -> s.withPriority(classifySection(s.header(), level)))
+                .toList();
+
+        return assembleWithBudget(classified, maxLength);
+    }
+
+    List<ResumeSection> splitIntoSections(String text) {
+        List<ResumeSection> sections = new ArrayList<>();
+        Matcher matcher = SECTION_HEADER.matcher(text);
+
+        List<int[]> headerPositions = new ArrayList<>();
+        while (matcher.find()) {
+            headerPositions.add(new int[]{matcher.start(), matcher.end()});
+        }
+
+        if (headerPositions.isEmpty()) {
+            sections.add(new ResumeSection(0, "", text, SectionPriority.P2));
+            return sections;
+        }
+
+        if (headerPositions.get(0)[0] > 0) {
+            String preamble = text.substring(0, headerPositions.get(0)[0]).trim();
+            if (!preamble.isEmpty()) {
+                sections.add(new ResumeSection(0, "", preamble, SectionPriority.P3));
+            }
+        }
+
+        for (int i = 0; i < headerPositions.size(); i++) {
+            String header = text.substring(headerPositions.get(i)[0], headerPositions.get(i)[1]).trim();
+            int bodyStart = headerPositions.get(i)[1];
+            int bodyEnd = (i + 1 < headerPositions.size()) ? headerPositions.get(i + 1)[0] : text.length();
+            String body = text.substring(bodyStart, bodyEnd).trim();
+            sections.add(new ResumeSection(sections.size(), header, body, SectionPriority.P2));
+        }
+
+        return sections;
+    }
+
+    SectionPriority classifySection(String headerLine, InterviewLevel level) {
+        if (headerLine == null || headerLine.isEmpty()) {
+            return SectionPriority.P3;
+        }
+
+        if (SKILLS_PATTERN.matcher(headerLine).find() || PROJECTS_PATTERN.matcher(headerLine).find()) {
+            return SectionPriority.P1;
+        }
+
+        if (EXPERIENCE_PATTERN.matcher(headerLine).find()) {
+            return level == InterviewLevel.SENIOR ? SectionPriority.P1 : SectionPriority.P2;
+        }
+
+        if (EDUCATION_PATTERN.matcher(headerLine).find()) {
+            return level == InterviewLevel.JUNIOR ? SectionPriority.P1 : SectionPriority.P3;
+        }
+
+        if (CERTIFICATIONS_PATTERN.matcher(headerLine).find()) {
+            return SectionPriority.P2;
+        }
+
+        if (AWARDS_PATTERN.matcher(headerLine).find()) {
+            return level == InterviewLevel.JUNIOR ? SectionPriority.P2 : SectionPriority.P3;
+        }
+
+        if (SUMMARY_PATTERN.matcher(headerLine).find()) {
+            return SectionPriority.P2;
+        }
+
+        if (CONTACT_PATTERN.matcher(headerLine).find()) {
+            return SectionPriority.P3;
+        }
+
+        return SectionPriority.P2;
+    }
+
+    String assembleWithBudget(List<ResumeSection> sections, int maxLength) {
+        List<ResumeSection> p1 = sections.stream().filter(s -> s.priority() == SectionPriority.P1).toList();
+        List<ResumeSection> p2 = sections.stream().filter(s -> s.priority() == SectionPriority.P2).toList();
+        List<ResumeSection> p3 = sections.stream().filter(s -> s.priority() == SectionPriority.P3).toList();
+
+        List<ResumeSection> included = new ArrayList<>();
+        int remainingBudget = maxLength;
+
+        remainingBudget = allocateSections(p1, included, remainingBudget);
+        remainingBudget = allocateSections(p2, included, remainingBudget);
+        allocateSections(p3, included, remainingBudget);
+
+        included.sort(Comparator.comparingInt(ResumeSection::index));
+
+        StringBuilder result = new StringBuilder();
+        for (ResumeSection section : included) {
+            if (!result.isEmpty()) {
+                result.append("\n");
+            }
+            if (!section.header().isEmpty()) {
+                result.append(section.header()).append("\n");
+            }
+            result.append(section.body());
+        }
+
+        return result.toString();
+    }
+
+    private int allocateSections(List<ResumeSection> sections, List<ResumeSection> included, int remainingBudget) {
+        for (ResumeSection section : sections) {
+            if (remainingBudget <= 0) break;
+
+            int sectionLength = section.length();
+            if (sectionLength <= remainingBudget) {
+                included.add(section);
+                remainingBudget -= sectionLength;
+            } else {
+                String truncatedBody = truncateSectionBody(section.body(), remainingBudget - section.header().length());
+                included.add(new ResumeSection(section.index(), section.header(), truncatedBody, section.priority()));
+                remainingBudget = 0;
+            }
+        }
+        return remainingBudget;
+    }
+
+    private String truncateSectionBody(String body, int budget) {
+        if (budget <= 0) return "";
+
+        String[] lines = body.split("\n");
+        if (lines.length <= 1) {
+            return body.substring(0, Math.min(body.length(), budget)) + "...";
+        }
+
+        StringBuilder result = new StringBuilder();
+        int includedCount = 0;
+
+        for (String line : lines) {
+            if (result.length() + line.length() + 1 > budget) break;
+            if (!result.isEmpty()) result.append("\n");
+            result.append(line);
+            includedCount++;
+        }
+
+        int remaining = lines.length - includedCount;
+        if (remaining > 0) {
+            result.append("\n... 외 ").append(remaining).append("개 항목");
+        }
+
+        return result.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ app:
 
 interview:
   prompt:
-    max-document-length: 1500
+    max-document-length: 5000
     max-job-posting-length: 1500
     max-history-tokens: 8000
     max-eval-history-tokens: 4000

--- a/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/document/service/DocumentServiceImplTest.java
@@ -2,6 +2,7 @@ package com.interviewai.backend.document.service;
 
 import com.interviewai.backend.client.PdfParserClient;
 import com.interviewai.backend.global.common.exception.BusinessException;
+import com.interviewai.backend.global.config.InterviewProperties;
 import com.interviewai.backend.document.controller.dto.DocumentListResponseDto;
 import com.interviewai.backend.document.enums.DocumentErrorCode;
 import com.interviewai.backend.document.enums.DocumentType;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +53,11 @@ class DocumentServiceImplTest {
     @Mock
     private PdfParserClient pdfParserClient;
 
+    @Mock
+    private InterviewProperties interviewProperties;
+
     private User testUser;
+    private static final String LONG_PARSED_TEXT = "이력서 테스트 내용입니다. 이 텍스트는 50자 이상이어야 이미지 PDF 감지를 통과합니다. 충분한 길이의 텍스트를 생성합니다.";
 
     @BeforeEach
     void setUp() {
@@ -63,6 +69,9 @@ class DocumentServiceImplTest {
                 .profileImageUrl(null)
                 .role(UserRole.USER)
                 .build();
+
+        InterviewProperties.Prompt promptProperties = new InterviewProperties.Prompt();
+        lenient().when(interviewProperties.getPrompt()).thenReturn(promptProperties);
     }
 
     @Test
@@ -100,11 +109,11 @@ class DocumentServiceImplTest {
                 .user(testUser)
                 .documentType(DocumentType.RESUME)
                 .originalFileName("resume.pdf")
-                .parsedText("이력서 내용")
+                .parsedText(LONG_PARSED_TEXT)
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-        given(pdfParserClient.parse(any())).willReturn("이력서 내용");
+        given(pdfParserClient.parse(any())).willReturn(LONG_PARSED_TEXT);
         given(userDocumentRepository.save(any(UserDocument.class))).willReturn(savedDocument);
 
         // when
@@ -114,6 +123,8 @@ class DocumentServiceImplTest {
         assertThat(response).isNotNull();
         assertThat(response.getDocumentType()).isEqualTo(DocumentType.RESUME);
         assertThat(response.getOriginalFileName()).isEqualTo("resume.pdf");
+        assertThat(response.getParsedTextLength()).isEqualTo(LONG_PARSED_TEXT.length());
+        assertThat(response.getMaxUsableLength()).isEqualTo(5000);
     }
 
     @Test
@@ -123,12 +134,13 @@ class DocumentServiceImplTest {
         Long userId = 1L;
         MockMultipartFile pdfFile = new MockMultipartFile(
                 "file", "resume.pdf", "application/pdf", "pdf content".getBytes());
-        String textWithNullBytes = "이력서\u0000내용\u0000";
+        String textWithNullBytes = "이력서\u0000내용입니다. 이 텍스트는 50자 이상이어야 이미지 PDF 감지를 통과합니다. 충분한 길이의 텍스트를 생성합니다.\u0000";
+        String cleanedText = textWithNullBytes.replace("\u0000", "");
         UserDocument savedDocument = UserDocument.builder()
                 .user(testUser)
                 .documentType(DocumentType.RESUME)
                 .originalFileName("resume.pdf")
-                .parsedText("이력서내용")
+                .parsedText(cleanedText)
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
@@ -188,6 +200,24 @@ class DocumentServiceImplTest {
         assertThat(result).isNotNull();
         assertThat(result.getTotalElements()).isZero();
         assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("예외_테스트_이미지_PDF는_텍스트_추출_불가_에러를_반환한다")
+    void 예외_테스트_이미지_PDF는_텍스트_추출_불가_에러를_반환한다() throws Exception {
+        // given
+        Long userId = 1L;
+        MockMultipartFile pdfFile = new MockMultipartFile(
+                "file", "scanned.pdf", "application/pdf", "pdf content".getBytes());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(pdfParserClient.parse(any())).willReturn("짧음");
+
+        // when & then
+        assertThatThrownBy(() -> documentService.uploadDocument(userId, pdfFile, DocumentType.RESUME))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(DocumentErrorCode.IMAGE_PDF_NOT_SUPPORTED));
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/global/config/InterviewPropertiesTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/InterviewPropertiesTest.java
@@ -13,7 +13,7 @@ class InterviewPropertiesTest {
     void 기능_테스트_기본값으로_InterviewProperties가_초기화된다() {
         InterviewProperties properties = new InterviewProperties();
 
-        assertThat(properties.getPrompt().getMaxDocumentLength()).isEqualTo(1500);
+        assertThat(properties.getPrompt().getMaxDocumentLength()).isEqualTo(5000);
         assertThat(properties.getPrompt().getMaxJobPostingLength()).isEqualTo(1500);
         assertThat(properties.getSse().getTimeoutMs()).isEqualTo(120_000L);
     }

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -105,6 +105,9 @@ class InterviewServiceImplTest {
     private TokenEstimator tokenEstimator;
 
     @Mock
+    private ResumeTextSummarizer resumeTextSummarizer;
+
+    @Mock
     private InterviewProperties interviewProperties;
 
     private User testUser;
@@ -1979,8 +1982,8 @@ class InterviewServiceImplTest {
     }
 
     @Test
-    @DisplayName("기능_테스트_startInterview_문서_텍스트_길이_초과시_절삭한다")
-    void 기능_테스트_startInterview_문서_텍스트_길이_초과시_절삭한다() {
+    @DisplayName("기능_테스트_startInterview_이력서_텍스트_길이_초과시_스마트_절삭한다")
+    void 기능_테스트_startInterview_이력서_텍스트_길이_초과시_스마트_절삭한다() {
         // given
         Long userId = 1L;
         InterviewStartRequestDto request = new InterviewStartRequestDto();
@@ -1988,11 +1991,15 @@ class InterviewServiceImplTest {
         setField(request, "level", InterviewLevel.JUNIOR);
         setField(request, "documentIds", List.of(1L));
 
-        // maxDocumentLength default is 1500, create text longer than that
-        String longText = "A".repeat(2000);
+        String longText = "A".repeat(6000);
+        String summarizedText = "요약된 이력서 내용";
         UserDocument doc = mock(UserDocument.class);
         when(doc.getDocumentType()).thenReturn(DocumentType.RESUME);
         when(doc.getParsedText()).thenReturn(longText);
+        when(doc.getOriginalFileName()).thenReturn("resume.pdf");
+
+        given(resumeTextSummarizer.summarize(eq(longText), eq(5000), eq(InterviewLevel.JUNIOR)))
+                .willReturn(summarizedText);
 
         InterviewSession savedSession = InterviewSession.builder()
                 .user(testUser).mode(InterviewMode.RESUME).level(InterviewLevel.JUNIOR).build();
@@ -2003,14 +2010,17 @@ class InterviewServiceImplTest {
         given(interviewSessionDocumentRepository.save(any(InterviewSessionDocument.class))).willReturn(null);
 
         // when
-        interviewService.startInterview(userId, request);
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
 
         // then
+        verify(resumeTextSummarizer).summarize(eq(longText), eq(5000), eq(InterviewLevel.JUNIOR));
         ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
         verify(interviewSessionRepository, times(2)).save(sessionCaptor.capture());
         String prompt = sessionCaptor.getAllValues().get(1).getSystemPrompt();
-        assertThat(prompt).contains("...");
-        assertThat(prompt).doesNotContain(longText); // full text not included
+        assertThat(prompt).contains(summarizedText);
+        assertThat(prompt).doesNotContain(longText);
+        assertThat(response.getDocumentTruncations()).hasSize(1);
+        assertThat(response.getDocumentTruncations().get(0).isTruncated()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/interview/service/ResumeTextSummarizerTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/ResumeTextSummarizerTest.java
@@ -1,0 +1,279 @@
+package com.interviewai.backend.interview.service;
+
+import com.interviewai.backend.interview.enums.InterviewLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ResumeTextSummarizer 테스트")
+class ResumeTextSummarizerTest {
+
+    private ResumeTextSummarizer summarizer;
+
+    @BeforeEach
+    void setUp() {
+        summarizer = new ResumeTextSummarizer();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_짧은_텍스트는_그대로_반환한다")
+    void 기능_테스트_짧은_텍스트는_그대로_반환한다() {
+        String text = "짧은 이력서 내용";
+        String result = summarizer.summarize(text, 5000, InterviewLevel.JUNIOR);
+        assertThat(result).isEqualTo(text);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_null_입력은_빈_문자열을_반환한다")
+    void 기능_테스트_null_입력은_빈_문자열을_반환한다() {
+        assertThat(summarizer.summarize(null, 5000, InterviewLevel.JUNIOR)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_빈_문자열은_빈_문자열을_반환한다")
+    void 기능_테스트_빈_문자열은_빈_문자열을_반환한다() {
+        assertThat(summarizer.summarize("", 5000, InterviewLevel.JUNIOR)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_섹션_미인식_시_fallback으로_substring_한다")
+    void 기능_테스트_섹션_미인식_시_fallback으로_substring_한다() {
+        String text = "A".repeat(6000);
+        String result = summarizer.summarize(text, 100, InterviewLevel.JUNIOR);
+        assertThat(result).hasSize(103); // 100 + "..."
+        assertThat(result).endsWith("...");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_한국어_이력서_JUNIOR_기술스택_프로젝트_학력_우선_포함한다")
+    void 기능_테스트_한국어_이력서_JUNIOR_기술스택_프로젝트_학력_우선_포함한다() {
+        String text = buildKoreanResume();
+        String result = summarizer.summarize(text, 300, InterviewLevel.JUNIOR);
+
+        assertThat(result).contains("기술 스택");
+        assertThat(result).contains("프로젝트 경험");
+        assertThat(result).contains("학력");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_한국어_이력서_SENIOR_기술스택_프로젝트_경력_우선_포함한다")
+    void 기능_테스트_한국어_이력서_SENIOR_기술스택_프로젝트_경력_우선_포함한다() {
+        String text = buildKoreanResume();
+        String result = summarizer.summarize(text, 300, InterviewLevel.SENIOR);
+
+        assertThat(result).contains("기술 스택");
+        assertThat(result).contains("프로젝트 경험");
+        assertThat(result).contains("경력 사항");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_영어_이력서_섹션을_인식한다")
+    void 기능_테스트_영어_이력서_섹션을_인식한다() {
+        String text = buildEnglishResume();
+        String result = summarizer.summarize(text, 300, InterviewLevel.JUNIOR);
+
+        assertThat(result).contains("Skills");
+        assertThat(result).contains("Projects");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_섹션_분류_JUNIOR_학력은_P1이다")
+    void 기능_테스트_섹션_분류_JUNIOR_학력은_P1이다() {
+        var priority = summarizer.classifySection("== 학력 ==", InterviewLevel.JUNIOR);
+        assertThat(priority).isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_섹션_분류_SENIOR_학력은_P3이다")
+    void 기능_테스트_섹션_분류_SENIOR_학력은_P3이다() {
+        var priority = summarizer.classifySection("== 학력 ==", InterviewLevel.SENIOR);
+        assertThat(priority).isEqualTo(ResumeTextSummarizer.SectionPriority.P3);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_섹션_분류_SENIOR_경력은_P1이다")
+    void 기능_테스트_섹션_분류_SENIOR_경력은_P1이다() {
+        var priority = summarizer.classifySection("경력 사항", InterviewLevel.SENIOR);
+        assertThat(priority).isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_섹션_분류_JUNIOR_경력은_P2이다")
+    void 기능_테스트_섹션_분류_JUNIOR_경력은_P2이다() {
+        var priority = summarizer.classifySection("경력 사항", InterviewLevel.JUNIOR);
+        assertThat(priority).isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_연락처는_항상_P3이다")
+    void 기능_테스트_연락처는_항상_P3이다() {
+        assertThat(summarizer.classifySection("연락처", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P3);
+        assertThat(summarizer.classifySection("Contact", InterviewLevel.SENIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P3);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_원본_순서가_유지된다")
+    void 기능_테스트_원본_순서가_유지된다() {
+        String text = """
+                == 연락처 ==
+                email@test.com
+                == 기술 스택 ==
+                Java, Spring Boot
+                == 프로젝트 경험 ==
+                AI 면접 서비스""";
+
+        // 기술스택과 프로젝트가 P1이지만, 원본에서 연락처가 앞에 있었으므로
+        // 포함된 섹션들은 원본 순서를 유지해야 함
+        String result = summarizer.summarize(text, 50, InterviewLevel.JUNIOR);
+        if (result.contains("기술 스택") && result.contains("프로젝트 경험")) {
+            int techIdx = result.indexOf("기술 스택");
+            int projectIdx = result.indexOf("프로젝트 경험");
+            assertThat(techIdx).isLessThan(projectIdx);
+        }
+    }
+
+    @Test
+    @DisplayName("기능_테스트_섹션_내_항목이_많으면_절삭_후_개수를_표시한다")
+    void 기능_테스트_섹션_내_항목이_많으면_절삭_후_개수를_표시한다() {
+        StringBuilder text = new StringBuilder();
+        text.append("== 프로젝트 경험 ==\n");
+        for (int i = 1; i <= 20; i++) {
+            text.append("프로젝트 ").append(i).append(": Spring Boot 기반 서비스 개발 및 운영 경험\n");
+        }
+        text.append("== 연락처 ==\nemail@test.com");
+
+        String result = summarizer.summarize(text.toString(), 200, InterviewLevel.JUNIOR);
+        assertThat(result).contains("외");
+        assertThat(result).contains("개 항목");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_splitIntoSections_정상_분리된다")
+    void 기능_테스트_splitIntoSections_정상_분리된다() {
+        String text = """
+                홍길동 개발자
+                == 기술 스택 ==
+                Java, Spring
+                == 프로젝트 경험 ==
+                AI 면접 서비스""";
+
+        List<ResumeTextSummarizer.ResumeSection> sections = summarizer.splitIntoSections(text);
+        assertThat(sections).hasSizeGreaterThanOrEqualTo(3); // preamble + 기술스택 + 프로젝트
+    }
+
+    @Test
+    @DisplayName("기능_테스트_데코레이터_헤더를_인식한다")
+    void 기능_테스트_데코레이터_헤더를_인식한다() {
+        assertThat(summarizer.classifySection("## 기술 스택", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+        assertThat(summarizer.classifySection("=== 프로젝트 경험 ===", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+        assertThat(summarizer.classifySection("1. 경력사항", InterviewLevel.SENIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+        assertThat(summarizer.classifySection("【학력】", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+        assertThat(summarizer.classifySection("Skills:", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P1);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_빈_헤더는_P3이다")
+    void 기능_테스트_빈_헤더는_P3이다() {
+        assertThat(summarizer.classifySection("", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P3);
+        assertThat(summarizer.classifySection(null, InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P3);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_자격증은_P2이다")
+    void 기능_테스트_자격증은_P2이다() {
+        assertThat(summarizer.classifySection("자격 사항", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+        assertThat(summarizer.classifySection("Certifications", InterviewLevel.SENIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_수상_JUNIOR는_P2_SENIOR는_P3이다")
+    void 기능_테스트_수상_JUNIOR는_P2_SENIOR는_P3이다() {
+        assertThat(summarizer.classifySection("수상 경력", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+        assertThat(summarizer.classifySection("Awards", InterviewLevel.SENIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P3);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_자기소개는_P2이다")
+    void 기능_테스트_자기소개는_P2이다() {
+        assertThat(summarizer.classifySection("자기 소개", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+        assertThat(summarizer.classifySection("About Me", InterviewLevel.SENIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_인식되지_않는_섹션은_P2이다")
+    void 기능_테스트_인식되지_않는_섹션은_P2이다() {
+        assertThat(summarizer.classifySection("기타 정보", InterviewLevel.JUNIOR))
+                .isEqualTo(ResumeTextSummarizer.SectionPriority.P2);
+    }
+
+    private String buildKoreanResume() {
+        return """
+                홍길동
+                서울특별시 강남구
+                email@test.com
+                == 연락처 ==
+                이메일: email@test.com
+                전화: 010-1234-5678
+                == 학력 ==
+                서울대학교 컴퓨터공학과 졸업 (2020.03 - 2024.02)
+                학점: 4.0 / 4.5
+                == 기술 스택 ==
+                Java, Spring Boot, PostgreSQL, Redis, Docker, Kubernetes
+                == 프로젝트 경험 ==
+                AI 면접 서비스 - Spring Boot 기반 백엔드 개발
+                실시간 채팅 서비스 - WebSocket + Redis Pub/Sub
+                == 경력 사항 ==
+                (주) 테크회사 백엔드 개발자 (2024.03 - 현재)
+                Spring Boot 기반 마이크로서비스 개발 및 운영
+                == 자격 사항 ==
+                정보처리기사 (2023.11)
+                == 수상 경력 ==
+                해커톤 대상 수상 (2023.09)
+                """;
+    }
+
+    private String buildEnglishResume() {
+        return """
+                John Doe
+                Seoul, South Korea
+                john@test.com
+                == Contact ==
+                Email: john@test.com
+                Phone: 010-1234-5678
+                == Education ==
+                Seoul National University, B.S. Computer Science (2020-2024)
+                GPA: 4.0 / 4.5
+                == Skills ==
+                Java, Spring Boot, PostgreSQL, Redis, Docker, Kubernetes
+                == Projects ==
+                AI Interview Service - Spring Boot backend development
+                Real-time Chat Service - WebSocket + Redis Pub/Sub
+                == Experience ==
+                Backend Developer at TechCorp (2024.03 - Present)
+                Microservice development and operation
+                == Certifications ==
+                Engineer Information Processing (2023.11)
+                == Awards ==
+                Hackathon Grand Prize (2023.09)
+                """;
+    }
+}


### PR DESCRIPTION
## Summary
- `ResumeTextSummarizer` 신규 — 정규식 섹션 인식 + JUNIOR/SENIOR 레벨별 우선순위(P1/P2/P3) + budget 기반 greedy 할당
- `maxDocumentLength` 1500 → 5000 상향
- 이미지 PDF 감지 (50자 미만 → `IMAGE_PDF_NOT_SUPPORTED` 에러)
- 문서 절삭 고지 DTO 추가 (업로드 응답 + 면접 시작 응답)

## Test plan
- [x] 긴 이력서 PDF (5000자 이상) 업로드 후 JUNIOR 면접 시작 → 기술스택/프로젝트/학력이 프롬프트에 포함되는지 확인
- [x] 같은 이력서로 SENIOR 면접 시작 → 기술스택/프로젝트/경력이 우선 포함되는지 확인
- [x] 짧은 이력서 (5000자 이하) → 절삭 없이 그대로 사용되는지 확인
- [ ] 이미지 기반 PDF 업로드 → 에러 메시지 반환 확인
- [ ] 업로드 응답에 `parsedTextLength`, `maxUsableLength`, `willBeTruncated` 포함 확인
- [ ] 면접 시작 응답에 `documentTruncations` 포함 확인

Closes #64