### PR TITLE
GitHub 정보 개선 — 언어 비율, 토픽, 최근 활동, 기술스택 요약 추가

### DIFF
--- a/src/main/java/com/interviewai/backend/client/GithubApiClient.java
+++ b/src/main/java/com/interviewai/backend/client/GithubApiClient.java
@@ -6,48 +6,76 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class GithubApiClient {
 
+    private static final String GITHUB_ACCEPT_HEADER = "application/vnd.github.v3+json";
+
+    private static final String LABEL_USERNAME = "GitHub 사용자: ";
+    private static final String LABEL_NAME = "이름: ";
+    private static final String LABEL_BIO = "바이오: ";
+    private static final String LABEL_PUBLIC_REPOS = "공개 레포: ";
+    private static final String LABEL_REPOS_SECTION = "주요 레포지토리:\n";
+    private static final String LABEL_TECH_STACK = "주요 기술스택: ";
+    private static final String LABEL_DESCRIPTION = "  설명: ";
+    private static final String LABEL_TOPICS = "  토픽: ";
+    private static final String LABEL_LANGUAGES = "  언어: ";
+    private static final String LABEL_LAST_ACTIVITY = " — 마지막 활동: ";
+    private static final String LABEL_README = "  README: ";
+
+    private static final String MSG_USERNAME_EXTRACT_FAILED = "GitHub URL에서 사용자명을 추출할 수 없습니다.";
+    private static final String MSG_API_FAILED = "GitHub 정보를 불러오는데 실패했습니다.";
+
     private final RestClient restClient;
     private final GithubApiProperties githubApiProperties;
+    private final ExecutorService githubExecutor;
 
     @Autowired
     public GithubApiClient(GithubApiProperties githubApiProperties) {
         this.githubApiProperties = githubApiProperties;
         this.restClient = RestClient.builder()
                 .baseUrl(githubApiProperties.getBaseUrl())
-                .defaultHeader("Accept", "application/vnd.github.v3+json")
+                .defaultHeader("Accept", GITHUB_ACCEPT_HEADER)
                 .build();
+        this.githubExecutor = Executors.newFixedThreadPool(4);
     }
 
     GithubApiClient(GithubApiProperties githubApiProperties, RestClient restClient) {
         this.githubApiProperties = githubApiProperties;
         this.restClient = restClient;
+        this.githubExecutor = Executors.newFixedThreadPool(4);
     }
 
     public String extractGithubInfo(String githubUrl) {
         String username = extractUsername(githubUrl);
         if (username == null) {
-            return "GitHub URL에서 사용자명을 추출할 수 없습니다.";
+            return MSG_USERNAME_EXTRACT_FAILED;
         }
 
         StringBuilder result = new StringBuilder();
-        result.append("GitHub 사용자: ").append(username).append("\n\n");
+        result.append(LABEL_USERNAME).append(username).append("\n\n");
 
         try {
             appendUserInfo(result, username);
-            appendRepositories(result, username);
+            Map<String, Long> totalLanguages = new LinkedHashMap<>();
+            appendRepositories(result, username, totalLanguages);
+            appendTechStackSummary(result, totalLanguages);
         } catch (Exception e) {
             log.warn("GitHub API 호출 실패: {}", e.getMessage());
-            result.append("GitHub 정보를 불러오는데 실패했습니다.");
+            result.append(MSG_API_FAILED);
         }
 
         return result.toString();
@@ -61,16 +89,16 @@ public class GithubApiClient {
                     .body(Map.class);
 
             if (userInfo != null) {
-                result.append("이름: ").append(userInfo.get("name")).append("\n");
-                result.append("바이오: ").append(userInfo.get("bio")).append("\n");
-                result.append("공개 레포: ").append(userInfo.get("public_repos")).append("개\n\n");
+                result.append(LABEL_NAME).append(userInfo.get("name")).append("\n");
+                result.append(LABEL_BIO).append(userInfo.get("bio")).append("\n");
+                result.append(LABEL_PUBLIC_REPOS).append(userInfo.get("public_repos")).append("개\n\n");
             }
         } catch (Exception e) {
             log.warn("GitHub 사용자 정보 조회 실패: {}", e.getMessage());
         }
     }
 
-    private void appendRepositories(StringBuilder result, String username) {
+    private void appendRepositories(StringBuilder result, String username, Map<String, Long> totalLanguages) {
         try {
             List<?> repos = restClient.get()
                     .uri("/users/{username}/repos?sort=updated&per_page={maxRepos}", username,
@@ -78,39 +106,138 @@ public class GithubApiClient {
                     .retrieve()
                     .body(List.class);
 
-            if (repos != null && !repos.isEmpty()) {
-                result.append("주요 레포지토리:\n");
+            if (repos == null || repos.isEmpty()) return;
 
-                Map<String, CompletableFuture<String>> readmeFutures = new LinkedHashMap<>();
-                for (Object repoObj : repos) {
-                    if (repoObj instanceof Map<?, ?> repo) {
-                        String repoName = (String) repo.get("name");
-                        result.append("- ").append(repoName);
-                        if (repo.get("description") != null) {
-                            result.append(": ").append(repo.get("description"));
+            result.append(LABEL_REPOS_SECTION);
+
+            Map<String, CompletableFuture<String>> readmeFutures = new LinkedHashMap<>();
+            Map<String, CompletableFuture<Map<String, Long>>> languageFutures = new LinkedHashMap<>();
+            List<Map<?, ?>> repoList = new ArrayList<>();
+
+            int timeoutSeconds = githubApiProperties.getParallelTimeoutSeconds();
+
+            for (Object repoObj : repos) {
+                if (repoObj instanceof Map<?, ?> repo) {
+                    repoList.add(repo);
+                    String repoName = (String) repo.get("name");
+                    if (!Boolean.TRUE.equals(repo.get("fork"))) {
+                        readmeFutures.put(repoName, CompletableFuture.supplyAsync(
+                                () -> fetchReadme(username, repoName), githubExecutor));
+                        languageFutures.put(repoName, CompletableFuture.supplyAsync(
+                                () -> fetchLanguages(username, repoName), githubExecutor));
+                    }
+                }
+            }
+
+            CompletableFuture.allOf(
+                    readmeFutures.values().toArray(new CompletableFuture[0])
+            ).orTimeout(timeoutSeconds, TimeUnit.SECONDS).exceptionally(e -> null).join();
+
+            CompletableFuture.allOf(
+                    languageFutures.values().toArray(new CompletableFuture[0])
+            ).orTimeout(timeoutSeconds, TimeUnit.SECONDS).exceptionally(e -> null).join();
+
+            for (Map<?, ?> repo : repoList) {
+                String repoName = (String) repo.get("name");
+                String language = (String) repo.get("language");
+                String pushedAt = formatDate((String) repo.get("pushed_at"));
+
+                result.append("- ").append(repoName);
+                if (language != null) {
+                    result.append(" [").append(language).append("]");
+                }
+                result.append(" (⭐").append(repo.get("stargazers_count")).append(")");
+                if (pushedAt != null) {
+                    result.append(LABEL_LAST_ACTIVITY).append(pushedAt);
+                }
+                result.append("\n");
+
+                if (repo.get("description") != null) {
+                    result.append(LABEL_DESCRIPTION).append(repo.get("description")).append("\n");
+                }
+
+                appendTopics(result, repo);
+
+                if (languageFutures.containsKey(repoName)) {
+                    try {
+                        Map<String, Long> languages = languageFutures.get(repoName).join();
+                        if (languages != null && !languages.isEmpty()) {
+                            appendLanguageBreakdown(result, languages);
+                            mergeLanguages(totalLanguages, languages);
                         }
-                        result.append(" (⭐").append(repo.get("stargazers_count")).append(")\n");
-                        if (!Boolean.TRUE.equals(repo.get("fork"))) {
-                            readmeFutures.put(repoName, CompletableFuture.supplyAsync(
-                                    () -> fetchReadme(username, repoName)
-                            ));
-                        }
+                    } catch (Exception e) {
+                        // 언어 정보 실패 무시
                     }
                 }
 
-                CompletableFuture.allOf(readmeFutures.values().toArray(new CompletableFuture[0]))
-                        .orTimeout(30, TimeUnit.SECONDS)
-                        .join();
-
-                for (Map.Entry<String, CompletableFuture<String>> entry : readmeFutures.entrySet()) {
-                    String readme = entry.getValue().join();
-                    if (readme != null) {
-                        result.append("  README: ").append(readme).append("\n");
+                if (readmeFutures.containsKey(repoName)) {
+                    try {
+                        String readme = readmeFutures.get(repoName).join();
+                        if (readme != null) {
+                            result.append(LABEL_README).append(readme).append("\n");
+                        }
+                    } catch (Exception e) {
+                        // README 실패 무시
                     }
                 }
             }
         } catch (Exception e) {
             log.warn("GitHub 레포지토리 조회 실패: {}", e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendTopics(StringBuilder result, Map<?, ?> repo) {
+        Object topicsObj = repo.get("topics");
+        if (topicsObj instanceof List<?> topics && !topics.isEmpty()) {
+            result.append(LABEL_TOPICS).append(
+                    ((List<String>) topics).stream().collect(Collectors.joining(", "))
+            ).append("\n");
+        }
+    }
+
+    private void appendLanguageBreakdown(StringBuilder result, Map<String, Long> languages) {
+        long total = languages.values().stream().mapToLong(Long::longValue).sum();
+        if (total == 0) return;
+
+        String breakdown = languages.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(githubApiProperties.getMaxLanguages())
+                .map(e -> e.getKey() + " " + (e.getValue() * 100 / total) + "%")
+                .collect(Collectors.joining(", "));
+        result.append(LABEL_LANGUAGES).append(breakdown).append("\n");
+    }
+
+    private void appendTechStackSummary(StringBuilder result, Map<String, Long> totalLanguages) {
+        if (totalLanguages.isEmpty()) return;
+
+        long total = totalLanguages.values().stream().mapToLong(Long::longValue).sum();
+        if (total == 0) return;
+
+        String summary = totalLanguages.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(githubApiProperties.getMaxLanguages())
+                .map(e -> e.getKey() + " (" + (e.getValue() * 100 / total) + "%)")
+                .collect(Collectors.joining(", "));
+
+        result.insert(result.indexOf(LABEL_REPOS_SECTION),
+                LABEL_TECH_STACK + summary + "\n\n");
+    }
+
+    Map<String, Long> fetchLanguages(String username, String repoName) {
+        try {
+            Map<?, ?> raw = restClient.get()
+                    .uri("/repos/{username}/{repo}/languages", username, repoName)
+                    .retrieve()
+                    .body(Map.class);
+            if (raw == null) return Map.of();
+            Map<String, Long> result = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : raw.entrySet()) {
+                result.put((String) entry.getKey(), ((Number) entry.getValue()).longValue());
+            }
+            return result;
+        } catch (Exception e) {
+            return Map.of();
         }
     }
 
@@ -134,6 +261,19 @@ public class GithubApiClient {
             // README 없는 경우 무시
         }
         return null;
+    }
+
+    private void mergeLanguages(Map<String, Long> total, Map<String, Long> repoLanguages) {
+        repoLanguages.forEach((lang, bytes) -> total.merge(lang, bytes, Long::sum));
+    }
+
+    private String formatDate(String isoDate) {
+        if (isoDate == null) return null;
+        try {
+            return LocalDate.parse(isoDate.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE).toString();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private String extractUsername(String githubUrl) {

--- a/src/main/java/com/interviewai/backend/client/GithubApiClient.java
+++ b/src/main/java/com/interviewai/backend/client/GithubApiClient.java
@@ -187,7 +187,7 @@ public class GithubApiClient {
     }
 
     @SuppressWarnings("unchecked")
-    private void appendTopics(StringBuilder result, Map<?, ?> repo) {
+    void appendTopics(StringBuilder result, Map<?, ?> repo) {
         Object topicsObj = repo.get("topics");
         if (topicsObj instanceof List<?> topics && !topics.isEmpty()) {
             result.append(LABEL_TOPICS).append(
@@ -196,7 +196,7 @@ public class GithubApiClient {
         }
     }
 
-    private void appendLanguageBreakdown(StringBuilder result, Map<String, Long> languages) {
+    void appendLanguageBreakdown(StringBuilder result, Map<String, Long> languages) {
         long total = languages.values().stream().mapToLong(Long::longValue).sum();
         if (total == 0) return;
 
@@ -208,7 +208,7 @@ public class GithubApiClient {
         result.append(LABEL_LANGUAGES).append(breakdown).append("\n");
     }
 
-    private void appendTechStackSummary(StringBuilder result, Map<String, Long> totalLanguages) {
+    void appendTechStackSummary(StringBuilder result, Map<String, Long> totalLanguages) {
         if (totalLanguages.isEmpty()) return;
 
         long total = totalLanguages.values().stream().mapToLong(Long::longValue).sum();
@@ -263,11 +263,11 @@ public class GithubApiClient {
         return null;
     }
 
-    private void mergeLanguages(Map<String, Long> total, Map<String, Long> repoLanguages) {
+    void mergeLanguages(Map<String, Long> total, Map<String, Long> repoLanguages) {
         repoLanguages.forEach((lang, bytes) -> total.merge(lang, bytes, Long::sum));
     }
 
-    private String formatDate(String isoDate) {
+    String formatDate(String isoDate) {
         if (isoDate == null) return null;
         try {
             return LocalDate.parse(isoDate.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE).toString();

--- a/src/main/java/com/interviewai/backend/global/config/GithubApiProperties.java
+++ b/src/main/java/com/interviewai/backend/global/config/GithubApiProperties.java
@@ -14,4 +14,6 @@ public class GithubApiProperties {
     private String baseUrl = "https://api.github.com";
     private int maxRepos = 10;
     private int maxReadmeLength = 500;
+    private int maxLanguages = 5;
+    private int parallelTimeoutSeconds = 30;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,8 @@ github:
     base-url: https://api.github.com
     max-repos: 10
     max-readme-length: 500
+    max-languages: 5
+    parallel-timeout-seconds: 30
 
 job-crawler:
   timeout-ms: 10000

--- a/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
@@ -40,6 +40,8 @@ class GithubApiClientTest {
     void setUp() {
         lenient().when(githubApiProperties.getMaxRepos()).thenReturn(10);
         lenient().when(githubApiProperties.getMaxReadmeLength()).thenReturn(500);
+        lenient().when(githubApiProperties.getMaxLanguages()).thenReturn(5);
+        lenient().when(githubApiProperties.getParallelTimeoutSeconds()).thenReturn(30);
         githubApiClient = new GithubApiClient(githubApiProperties, restClient);
     }
 
@@ -419,9 +421,98 @@ class GithubApiClientTest {
     @Test
     @DisplayName("기능_테스트_github_com이_마지막_토큰인_URL이면_사용자명_추출_불가_메시지가_반환된다")
     void 기능_테스트_github_com이_마지막_토큰인_URL이면_사용자명_추출_불가_메시지가_반환된다() {
-        // URL like "https://github.com" — github.com is at parts[2], parts[3] doesn't exist
         String result = githubApiClient.extractGithubInfo("https://github.com");
 
         assertThat(result).contains("사용자명을 추출할 수 없습니다");
+    }
+
+    // -----------------------------------------------------------------------
+    // fetchLanguages 단위 테스트
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_언어_비율이_정상_반환된다")
+    void 기능_테스트_언어_비율이_정상_반환된다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(Map.of("Java", 50000, "Kotlin", 3000));
+
+        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo");
+
+        assertThat(result).containsEntry("Java", 50000L);
+        assertThat(result).containsEntry("Kotlin", 3000L);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_언어_API_실패시_빈_맵이_반환된다")
+    void 기능_테스트_언어_API_실패시_빈_맵이_반환된다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenThrow(new RuntimeException("API 실패"));
+
+        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_언어_API가_null_반환시_빈_맵이_반환된다")
+    void 기능_테스트_언어_API가_null_반환시_빈_맵이_반환된다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(null);
+
+        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo");
+
+        assertThat(result).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // 통합 테스트 — 언어, 토픽, 최근 활동 포함
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_레포에_주_언어와_최근_활동_날짜가_포맷된다")
+    void 기능_테스트_레포에_주_언어와_최근_활동_날짜가_포맷된다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+
+        Map<String, Object> userInfo = Map.of(
+                "name", "Test User", "bio", "Developer", "public_repos", 1);
+
+        Map<String, Object> repo = new java.util.HashMap<>();
+        repo.put("name", "my-project");
+        repo.put("description", "Spring Boot 프로젝트");
+        repo.put("stargazers_count", 5);
+        repo.put("fork", true);
+        repo.put("language", "Java");
+        repo.put("pushed_at", "2026-04-25T10:00:00Z");
+
+        // fork=true이므로 README/Language 병렬 호출 없음 → 순차 mock 가능
+        when(responseSpec.body(any(Class.class)))
+                .thenReturn(userInfo)
+                .thenReturn(List.of(repo));
+
+        String result = githubApiClient.extractGithubInfo("https://github.com/testuser");
+
+        assertThat(result).contains("[Java]");
+        assertThat(result).contains("마지막 활동: 2026-04-25");
+        assertThat(result).contains("설명: Spring Boot 프로젝트");
     }
 }

--- a/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
@@ -482,6 +482,124 @@ class GithubApiClientTest {
     // 통합 테스트 — 언어, 토픽, 최근 활동 포함
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // appendTopics / appendLanguageBreakdown / appendTechStackSummary / mergeLanguages / formatDate 단위 테스트
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_토픽이_있으면_결과에_포함된다")
+    void 기능_테스트_토픽이_있으면_결과에_포함된다() {
+        StringBuilder result = new StringBuilder();
+        Map<String, Object> repo = new java.util.HashMap<>();
+        repo.put("topics", List.of("spring-boot", "docker", "kubernetes"));
+
+        githubApiClient.appendTopics(result, repo);
+
+        assertThat(result.toString()).contains("토픽: spring-boot, docker, kubernetes");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_토픽이_없으면_결과에_추가되지_않는다")
+    void 기능_테스트_토픽이_없으면_결과에_추가되지_않는다() {
+        StringBuilder result = new StringBuilder();
+        Map<String, Object> repo = new java.util.HashMap<>();
+
+        githubApiClient.appendTopics(result, repo);
+
+        assertThat(result.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_토픽이_빈_리스트이면_결과에_추가되지_않는다")
+    void 기능_테스트_토픽이_빈_리스트이면_결과에_추가되지_않는다() {
+        StringBuilder result = new StringBuilder();
+        Map<String, Object> repo = Map.of("topics", List.of());
+
+        githubApiClient.appendTopics(result, repo);
+
+        assertThat(result.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_언어_비율이_퍼센트로_표시된다")
+    void 기능_테스트_언어_비율이_퍼센트로_표시된다() {
+        StringBuilder result = new StringBuilder();
+        Map<String, Long> languages = new java.util.LinkedHashMap<>();
+        languages.put("Java", 70000L);
+        languages.put("Kotlin", 30000L);
+
+        githubApiClient.appendLanguageBreakdown(result, languages);
+
+        assertThat(result.toString()).contains("언어: Java 70%, Kotlin 30%");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_언어_합계가_0이면_결과에_추가되지_않는다")
+    void 기능_테스트_언어_합계가_0이면_결과에_추가되지_않는다() {
+        StringBuilder result = new StringBuilder();
+        Map<String, Long> languages = Map.of("Java", 0L);
+
+        githubApiClient.appendLanguageBreakdown(result, languages);
+
+        assertThat(result.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_기술스택_요약이_레포_섹션_앞에_삽입된다")
+    void 기능_테스트_기술스택_요약이_레포_섹션_앞에_삽입된다() {
+        StringBuilder result = new StringBuilder("주요 레포지토리:\n- repo1\n");
+        Map<String, Long> totalLanguages = new java.util.LinkedHashMap<>();
+        totalLanguages.put("Java", 80000L);
+        totalLanguages.put("Python", 20000L);
+
+        githubApiClient.appendTechStackSummary(result, totalLanguages);
+
+        String output = result.toString();
+        assertThat(output).contains("주요 기술스택: Java (80%), Python (20%)");
+        assertThat(output.indexOf("주요 기술스택")).isLessThan(output.indexOf("주요 레포지토리"));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_빈_언어_맵이면_기술스택_요약이_추가되지_않는다")
+    void 기능_테스트_빈_언어_맵이면_기술스택_요약이_추가되지_않는다() {
+        StringBuilder result = new StringBuilder("주요 레포지토리:\n");
+        Map<String, Long> empty = Map.of();
+
+        githubApiClient.appendTechStackSummary(result, empty);
+
+        assertThat(result.toString()).doesNotContain("주요 기술스택");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_언어_병합이_정상_동작한다")
+    void 기능_테스트_언어_병합이_정상_동작한다() {
+        Map<String, Long> total = new java.util.LinkedHashMap<>();
+        total.put("Java", 50000L);
+
+        githubApiClient.mergeLanguages(total, Map.of("Java", 30000L, "Kotlin", 10000L));
+
+        assertThat(total).containsEntry("Java", 80000L);
+        assertThat(total).containsEntry("Kotlin", 10000L);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_ISO_날짜가_포맷된다")
+    void 기능_테스트_ISO_날짜가_포맷된다() {
+        assertThat(githubApiClient.formatDate("2026-04-25T10:00:00Z")).isEqualTo("2026-04-25");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_null_날짜는_null_반환한다")
+    void 기능_테스트_null_날짜는_null_반환한다() {
+        assertThat(githubApiClient.formatDate(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_잘못된_날짜는_null_반환한다")
+    void 기능_테스트_잘못된_날짜는_null_반환한다() {
+        assertThat(githubApiClient.formatDate("invalid")).isNull();
+    }
+
     @Test
     @DisplayName("기능_테스트_레포에_주_언어와_최근_활동_날짜가_포맷된다")
     void 기능_테스트_레포에_주_언어와_최근_활동_날짜가_포맷된다() {

--- a/src/test/java/com/interviewai/backend/global/config/GithubApiPropertiesTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/GithubApiPropertiesTest.java
@@ -16,6 +16,8 @@ class GithubApiPropertiesTest {
         assertThat(properties.getBaseUrl()).isEqualTo("https://api.github.com");
         assertThat(properties.getMaxRepos()).isEqualTo(10);
         assertThat(properties.getMaxReadmeLength()).isEqualTo(500);
+        assertThat(properties.getMaxLanguages()).isEqualTo(5);
+        assertThat(properties.getParallelTimeoutSeconds()).isEqualTo(30);
     }
 
     @Test
@@ -25,9 +27,13 @@ class GithubApiPropertiesTest {
         properties.setBaseUrl("https://api.github.enterprise.com");
         properties.setMaxRepos(20);
         properties.setMaxReadmeLength(1000);
+        properties.setMaxLanguages(10);
+        properties.setParallelTimeoutSeconds(60);
 
         assertThat(properties.getBaseUrl()).isEqualTo("https://api.github.enterprise.com");
         assertThat(properties.getMaxRepos()).isEqualTo(20);
         assertThat(properties.getMaxReadmeLength()).isEqualTo(1000);
+        assertThat(properties.getMaxLanguages()).isEqualTo(10);
+        assertThat(properties.getParallelTimeoutSeconds()).isEqualTo(60);
     }
 }


### PR DESCRIPTION
## Summary
- 레포별 주 프로그래밍 언어, 토픽, 최근 활동일 표시
- 레포별 언어 비율을 Language API로 병렬 수집
- 전체 기술스택 요약 (상위 N개 언어 비율) 자동 생성
- 매직 문자열 상수 분리, 전용 ExecutorService, 타임아웃 외부화

## Test plan
- [ ] 실제 GitHub URL로 면접 시작 → 프롬프트에 언어 비율, 토픽, 최근 활동 포함 확인
- [ ] 주요 기술스택 요약 표시 확인
- [ ] GitHub API 실패 시에도 면접 정상 진행 확인

Closes #66