### PR TITLE
GitHub OAuth 토큰 저장 + 인증된 API 호출 (시간당 5000회)

### DIFF
--- a/src/main/java/com/interviewai/backend/client/GithubApiClient.java
+++ b/src/main/java/com/interviewai/backend/client/GithubApiClient.java
@@ -60,18 +60,24 @@ public class GithubApiClient {
     }
 
     public String extractGithubInfo(String githubUrl) {
+        return extractGithubInfo(githubUrl, null);
+    }
+
+    public String extractGithubInfo(String githubUrl, String accessToken) {
         String username = extractUsername(githubUrl);
         if (username == null) {
             return MSG_USERNAME_EXTRACT_FAILED;
         }
 
+        RestClient client = buildClient(accessToken);
+
         StringBuilder result = new StringBuilder();
         result.append(LABEL_USERNAME).append(username).append("\n\n");
 
         try {
-            appendUserInfo(result, username);
+            appendUserInfo(result, username, client);
             Map<String, Long> totalLanguages = new LinkedHashMap<>();
-            appendRepositories(result, username, totalLanguages);
+            appendRepositories(result, username, totalLanguages, client);
             appendTechStackSummary(result, totalLanguages);
         } catch (Exception e) {
             log.warn("GitHub API 호출 실패: {}", e.getMessage());
@@ -81,9 +87,20 @@ public class GithubApiClient {
         return result.toString();
     }
 
-    private void appendUserInfo(StringBuilder result, String username) {
+    private RestClient buildClient(String accessToken) {
+        if (accessToken == null) {
+            return restClient;
+        }
+        return RestClient.builder()
+                .baseUrl(githubApiProperties.getBaseUrl())
+                .defaultHeader("Accept", GITHUB_ACCEPT_HEADER)
+                .defaultHeader("Authorization", "Bearer " + accessToken)
+                .build();
+    }
+
+    private void appendUserInfo(StringBuilder result, String username, RestClient client) {
         try {
-            Map<?, ?> userInfo = restClient.get()
+            Map<?, ?> userInfo = client.get()
                     .uri("/users/{username}", username)
                     .retrieve()
                     .body(Map.class);
@@ -98,9 +115,9 @@ public class GithubApiClient {
         }
     }
 
-    private void appendRepositories(StringBuilder result, String username, Map<String, Long> totalLanguages) {
+    private void appendRepositories(StringBuilder result, String username, Map<String, Long> totalLanguages, RestClient client) {
         try {
-            List<?> repos = restClient.get()
+            List<?> repos = client.get()
                     .uri("/users/{username}/repos?sort=updated&per_page={maxRepos}", username,
                             githubApiProperties.getMaxRepos())
                     .retrieve()
@@ -122,9 +139,9 @@ public class GithubApiClient {
                     String repoName = (String) repo.get("name");
                     if (!Boolean.TRUE.equals(repo.get("fork"))) {
                         readmeFutures.put(repoName, CompletableFuture.supplyAsync(
-                                () -> fetchReadme(username, repoName), githubExecutor));
+                                () -> fetchReadme(username, repoName, client), githubExecutor));
                         languageFutures.put(repoName, CompletableFuture.supplyAsync(
-                                () -> fetchLanguages(username, repoName), githubExecutor));
+                                () -> fetchLanguages(username, repoName, client), githubExecutor));
                     }
                 }
             }
@@ -224,9 +241,9 @@ public class GithubApiClient {
                 LABEL_TECH_STACK + summary + "\n\n");
     }
 
-    Map<String, Long> fetchLanguages(String username, String repoName) {
+    Map<String, Long> fetchLanguages(String username, String repoName, RestClient client) {
         try {
-            Map<?, ?> raw = restClient.get()
+            Map<?, ?> raw = client.get()
                     .uri("/repos/{username}/{repo}/languages", username, repoName)
                     .retrieve()
                     .body(Map.class);
@@ -241,9 +258,9 @@ public class GithubApiClient {
         }
     }
 
-    String fetchReadme(String username, String repoName) {
+    String fetchReadme(String username, String repoName, RestClient client) {
         try {
-            Map<?, ?> readme = restClient.get()
+            Map<?, ?> readme = client.get()
                     .uri("/repos/{username}/{repo}/readme", username, repoName)
                     .retrieve()
                     .body(Map.class);

--- a/src/main/java/com/interviewai/backend/client/GithubApiClient.java
+++ b/src/main/java/com/interviewai/backend/client/GithubApiClient.java
@@ -87,7 +87,7 @@ public class GithubApiClient {
         return result.toString();
     }
 
-    private RestClient buildClient(String accessToken) {
+    RestClient buildClient(String accessToken) {
         if (accessToken == null) {
             return restClient;
         }

--- a/src/main/java/com/interviewai/backend/global/config/EncryptedStringConverter.java
+++ b/src/main/java/com/interviewai/backend/global/config/EncryptedStringConverter.java
@@ -19,6 +19,7 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
     private static final String TRANSFORMATION = "AES/GCM/NoPadding";
     private static final int GCM_IV_LENGTH = 12;
     private static final int GCM_TAG_LENGTH = 128;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final SecretKeySpec secretKey;
 
@@ -34,7 +35,7 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
         if (attribute == null) return null;
         try {
             byte[] iv = new byte[GCM_IV_LENGTH];
-            new SecureRandom().nextBytes(iv);
+            SECURE_RANDOM.nextBytes(iv);
 
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
             cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));

--- a/src/main/java/com/interviewai/backend/global/config/EncryptedStringConverter.java
+++ b/src/main/java/com/interviewai/backend/global/config/EncryptedStringConverter.java
@@ -1,0 +1,53 @@
+package com.interviewai.backend.global.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+@Component
+@Converter
+public class EncryptedStringConverter implements AttributeConverter<String, String> {
+
+    private static final String ALGORITHM = "AES";
+
+    private final SecretKeySpec secretKey;
+
+    public EncryptedStringConverter(@Value("${encryption.secret-key}") String key) {
+        byte[] keyBytes = key.getBytes();
+        if (keyBytes.length != 16 && keyBytes.length != 24 && keyBytes.length != 32) {
+            byte[] padded = new byte[16];
+            System.arraycopy(keyBytes, 0, padded, 0, Math.min(keyBytes.length, 16));
+            keyBytes = padded;
+        }
+        this.secretKey = new SecretKeySpec(keyBytes, ALGORITHM);
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            return Base64.getEncoder().encodeToString(cipher.doFinal(attribute.getBytes()));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encrypt", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey);
+            return new String(cipher.doFinal(Base64.getDecoder().decode(dbData)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to decrypt", e);
+        }
+    }
+}

--- a/src/main/java/com/interviewai/backend/global/config/EncryptedStringConverter.java
+++ b/src/main/java/com/interviewai/backend/global/config/EncryptedStringConverter.java
@@ -6,7 +6,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
 import java.util.Base64;
 
 @Component
@@ -14,16 +16,16 @@ import java.util.Base64;
 public class EncryptedStringConverter implements AttributeConverter<String, String> {
 
     private static final String ALGORITHM = "AES";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 128;
 
     private final SecretKeySpec secretKey;
 
     public EncryptedStringConverter(@Value("${encryption.secret-key}") String key) {
-        byte[] keyBytes = key.getBytes();
-        if (keyBytes.length != 16 && keyBytes.length != 24 && keyBytes.length != 32) {
-            byte[] padded = new byte[16];
-            System.arraycopy(keyBytes, 0, padded, 0, Math.min(keyBytes.length, 16));
-            keyBytes = padded;
-        }
+        byte[] keyBytes = new byte[16];
+        byte[] source = key.getBytes();
+        System.arraycopy(source, 0, keyBytes, 0, Math.min(source.length, 16));
         this.secretKey = new SecretKeySpec(keyBytes, ALGORITHM);
     }
 
@@ -31,9 +33,18 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
     public String convertToDatabaseColumn(String attribute) {
         if (attribute == null) return null;
         try {
-            Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
-            return Base64.getEncoder().encodeToString(cipher.doFinal(attribute.getBytes()));
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            byte[] encrypted = cipher.doFinal(attribute.getBytes());
+
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+
+            return Base64.getEncoder().encodeToString(combined);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to encrypt", e);
         }
@@ -43,9 +54,17 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
     public String convertToEntityAttribute(String dbData) {
         if (dbData == null) return null;
         try {
-            Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.DECRYPT_MODE, secretKey);
-            return new String(cipher.doFinal(Base64.getDecoder().decode(dbData)));
+            byte[] combined = Base64.getDecoder().decode(dbData);
+
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            System.arraycopy(combined, 0, iv, 0, iv.length);
+
+            byte[] encrypted = new byte[combined.length - iv.length];
+            System.arraycopy(combined, iv.length, encrypted, 0, encrypted.length);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            return new String(cipher.doFinal(encrypted));
         } catch (Exception e) {
             throw new IllegalStateException("Failed to decrypt", e);
         }

--- a/src/main/java/com/interviewai/backend/global/config/InterviewProperties.java
+++ b/src/main/java/com/interviewai/backend/global/config/InterviewProperties.java
@@ -13,6 +13,8 @@ public class InterviewProperties {
 
     private Prompt prompt = new Prompt();
     private Sse sse = new Sse();
+    private int crawlTimeoutSeconds = 15;
+    private int githubTimeoutSeconds = 30;
 
     @Getter
     @Setter

--- a/src/main/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserService.java
@@ -32,9 +32,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuthProvider provider = OAuthProvider.valueOf(registrationId.toUpperCase());
         OAuth2UserInfo userInfo = resolveOAuth2UserInfo(provider, attributes);
 
+        String githubToken = provider == OAuthProvider.GITHUB
+                ? userRequest.getAccessToken().getTokenValue() : null;
+
         User user = userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
                 .map(existing -> {
                     existing.updateProfile(userInfo.getName(), userInfo.getEmail(), userInfo.getProfileImageUrl());
+                    if (githubToken != null) {
+                        existing.updateGithubAccessToken(githubToken);
+                    }
                     return existing;
                 })
                 .orElseGet(() -> userRepository.save(
@@ -44,6 +50,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 .email(userInfo.getEmail())
                                 .name(userInfo.getName())
                                 .profileImageUrl(userInfo.getProfileImageUrl())
+                                .githubAccessToken(githubToken)
                                 .role(UserRole.USER)
                                 .build()
                 ));

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -86,12 +86,13 @@ public class InterviewServiceImpl implements InterviewService {
 
         CompletableFuture<String> githubFuture = null;
         if (request.getGithubUrl() != null) {
+            String githubToken = user.getGithubAccessToken();
             githubFuture = CompletableFuture.supplyAsync(
-                    () -> githubApiClient.extractGithubInfo(request.getGithubUrl()));
+                    () -> githubApiClient.extractGithubInfo(request.getGithubUrl(), githubToken));
         }
 
-        String jobPostingContent = joinSafely(crawlFuture, 15);
-        String githubInfo = joinSafely(githubFuture, 30);
+        String jobPostingContent = joinSafely(crawlFuture, interviewProperties.getCrawlTimeoutSeconds());
+        String githubInfo = joinSafely(githubFuture, interviewProperties.getGithubTimeoutSeconds());
 
         InterviewSession session = InterviewSession.builder()
                 .user(user)

--- a/src/main/java/com/interviewai/backend/user/model/User.java
+++ b/src/main/java/com/interviewai/backend/user/model/User.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {})
+@ToString(exclude = {"githubAccessToken"})
 public class User {
 
     @Id
@@ -35,6 +35,9 @@ public class User {
 
     private String profileImageUrl;
 
+    @Convert(converter = com.interviewai.backend.global.config.EncryptedStringConverter.class)
+    private String githubAccessToken;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
@@ -49,12 +52,13 @@ public class User {
 
     @Builder
     public User(String providerId, OAuthProvider provider, String email, String name,
-                String profileImageUrl, UserRole role) {
+                String profileImageUrl, String githubAccessToken, UserRole role) {
         this.providerId = providerId;
         this.provider = provider;
         this.email = email;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+        this.githubAccessToken = githubAccessToken;
         this.role = role;
     }
 
@@ -62,5 +66,9 @@ public class User {
         this.name = name;
         this.email = email;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateGithubAccessToken(String githubAccessToken) {
+        this.githubAccessToken = githubAccessToken;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,6 +85,9 @@ github:
     max-languages: 5
     parallel-timeout-seconds: 30
 
+encryption:
+  secret-key: ${ENCRYPTION_SECRET_KEY}
+
 job-crawler:
   timeout-ms: 10000
   max-text-length: 3000

--- a/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
@@ -110,7 +110,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(Map.of("content", encoded));
 
-        String result = githubApiClient.fetchReadme("testuser", "testrepo");
+        String result = githubApiClient.fetchReadme("testuser", "testrepo", restClient);
 
         assertThat(result).isEqualTo("Hello README");
     }
@@ -126,7 +126,7 @@ class GithubApiClientTest {
         when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
         when(headersSpec.retrieve()).thenThrow(new RuntimeException("404 Not Found"));
 
-        String result = githubApiClient.fetchReadme("testuser", "norepo");
+        String result = githubApiClient.fetchReadme("testuser", "norepo", restClient);
 
         assertThat(result).isNull();
     }
@@ -143,7 +143,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(Map.of("type", "file"));
 
-        String result = githubApiClient.fetchReadme("testuser", "testrepo");
+        String result = githubApiClient.fetchReadme("testuser", "testrepo", restClient);
 
         assertThat(result).isNull();
     }
@@ -160,7 +160,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(null);
 
-        String result = githubApiClient.fetchReadme("testuser", "testrepo");
+        String result = githubApiClient.fetchReadme("testuser", "testrepo", restClient);
 
         assertThat(result).isNull();
     }
@@ -181,7 +181,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(Map.of("content", encoded));
 
-        String result = githubApiClient.fetchReadme("testuser", "testrepo");
+        String result = githubApiClient.fetchReadme("testuser", "testrepo", restClient);
 
         assertThat(result).endsWith("...");
         assertThat(result).hasSize(503); // 500 chars + "..."
@@ -202,7 +202,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(Map.of("content", encoded));
 
-        String result = githubApiClient.fetchReadme("testuser", "testrepo");
+        String result = githubApiClient.fetchReadme("testuser", "testrepo", restClient);
 
         assertThat(result).doesNotEndWith("...");
         assertThat(result).hasSize(500);
@@ -442,7 +442,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(Map.of("Java", 50000, "Kotlin", 3000));
 
-        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo");
+        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo", restClient);
 
         assertThat(result).containsEntry("Java", 50000L);
         assertThat(result).containsEntry("Kotlin", 3000L);
@@ -456,7 +456,7 @@ class GithubApiClientTest {
         when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
         when(uriSpec.uri(anyString(), any(Object[].class))).thenThrow(new RuntimeException("API 실패"));
 
-        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo");
+        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo", restClient);
 
         assertThat(result).isEmpty();
     }
@@ -473,7 +473,7 @@ class GithubApiClientTest {
         when(headersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(Class.class))).thenReturn(null);
 
-        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo");
+        Map<String, Long> result = githubApiClient.fetchLanguages("testuser", "testrepo", restClient);
 
         assertThat(result).isEmpty();
     }

--- a/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
@@ -600,6 +600,42 @@ class GithubApiClientTest {
         assertThat(githubApiClient.formatDate("invalid")).isNull();
     }
 
+    // -----------------------------------------------------------------------
+    // buildClient 테스트
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_accessToken이_null이면_기본_RestClient를_반환한다")
+    void 기능_테스트_accessToken이_null이면_기본_RestClient를_반환한다() {
+        lenient().when(githubApiProperties.getBaseUrl()).thenReturn("https://api.github.com");
+        RestClient result = githubApiClient.buildClient(null);
+        assertThat(result).isSameAs(restClient);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_accessToken이_있으면_새_RestClient를_반환한다")
+    void 기능_테스트_accessToken이_있으면_새_RestClient를_반환한다() {
+        lenient().when(githubApiProperties.getBaseUrl()).thenReturn("https://api.github.com");
+        RestClient result = githubApiClient.buildClient("gho_test_token");
+        assertThat(result).isNotSameAs(restClient);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_extractGithubInfo_토큰_없이_호출_가능하다")
+    void 기능_테스트_extractGithubInfo_토큰_없이_호출_가능하다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(null);
+
+        String result = githubApiClient.extractGithubInfo("https://github.com/testuser", null);
+        assertThat(result).contains("testuser");
+    }
+
     @Test
     @DisplayName("기능_테스트_레포에_주_언어와_최근_활동_날짜가_포맷된다")
     void 기능_테스트_레포에_주_언어와_최근_활동_날짜가_포맷된다() {

--- a/src/test/java/com/interviewai/backend/global/config/EncryptedStringConverterTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/EncryptedStringConverterTest.java
@@ -1,0 +1,76 @@
+package com.interviewai.backend.global.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("EncryptedStringConverter 테스트")
+class EncryptedStringConverterTest {
+
+    private EncryptedStringConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new EncryptedStringConverter("test-encrypt-key!");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_문자열을_암호화하고_복호화하면_원본과_동일하다")
+    void 기능_테스트_문자열을_암호화하고_복호화하면_원본과_동일하다() {
+        String original = "ghp_test_token_12345";
+
+        String encrypted = converter.convertToDatabaseColumn(original);
+        String decrypted = converter.convertToEntityAttribute(encrypted);
+
+        assertThat(decrypted).isEqualTo(original);
+        assertThat(encrypted).isNotEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_null_입력은_null을_반환한다_암호화")
+    void 기능_테스트_null_입력은_null을_반환한다_암호화() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_null_입력은_null을_반환한다_복호화")
+    void 기능_테스트_null_입력은_null을_반환한다_복호화() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_같은_문자열을_두번_암호화하면_다른_결과가_나온다")
+    void 기능_테스트_같은_문자열을_두번_암호화하면_다른_결과가_나온다() {
+        String original = "test_token";
+
+        String encrypted1 = converter.convertToDatabaseColumn(original);
+        String encrypted2 = converter.convertToDatabaseColumn(original);
+
+        assertThat(encrypted1).isNotEqualTo(encrypted2);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_긴_토큰도_정상_암복호화된다")
+    void 기능_테스트_긴_토큰도_정상_암복호화된다() {
+        String longToken = "github_pat_" + "A".repeat(200);
+
+        String encrypted = converter.convertToDatabaseColumn(longToken);
+        String decrypted = converter.convertToEntityAttribute(encrypted);
+
+        assertThat(decrypted).isEqualTo(longToken);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_짧은_키로도_정상_동작한다")
+    void 기능_테스트_짧은_키로도_정상_동작한다() {
+        EncryptedStringConverter shortKeyConverter = new EncryptedStringConverter("short");
+
+        String original = "test_token";
+        String encrypted = shortKeyConverter.convertToDatabaseColumn(original);
+        String decrypted = shortKeyConverter.convertToEntityAttribute(encrypted);
+
+        assertThat(decrypted).isEqualTo(original);
+    }
+}

--- a/src/test/java/com/interviewai/backend/global/config/InterviewPropertiesTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/InterviewPropertiesTest.java
@@ -16,6 +16,8 @@ class InterviewPropertiesTest {
         assertThat(properties.getPrompt().getMaxDocumentLength()).isEqualTo(5000);
         assertThat(properties.getPrompt().getMaxJobPostingLength()).isEqualTo(1500);
         assertThat(properties.getSse().getTimeoutMs()).isEqualTo(120_000L);
+        assertThat(properties.getCrawlTimeoutSeconds()).isEqualTo(15);
+        assertThat(properties.getGithubTimeoutSeconds()).isEqualTo(30);
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,80 @@
+package com.interviewai.backend.global.config.oauth;
+
+import com.interviewai.backend.user.enums.OAuthProvider;
+import com.interviewai.backend.user.enums.UserRole;
+import com.interviewai.backend.user.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CustomOAuth2UserService 토큰 저장 로직 테스트")
+class CustomOAuth2UserServiceTest {
+
+    @Test
+    @DisplayName("기능_테스트_GitHub_신규_사용자_생성시_토큰이_포함된다")
+    void 기능_테스트_GitHub_신규_사용자_생성시_토큰이_포함된다() {
+        User user = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("test@test.com")
+                .name("testuser")
+                .githubAccessToken("gho_test_token")
+                .role(UserRole.USER)
+                .build();
+
+        assertThat(user.getGithubAccessToken()).isEqualTo("gho_test_token");
+        assertThat(user.getProvider()).isEqualTo(OAuthProvider.GITHUB);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_기존_GitHub_사용자_재로그인시_토큰이_갱신된다")
+    void 기능_테스트_기존_GitHub_사용자_재로그인시_토큰이_갱신된다() {
+        User user = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("test@test.com")
+                .name("testuser")
+                .role(UserRole.USER)
+                .build();
+
+        assertThat(user.getGithubAccessToken()).isNull();
+
+        user.updateGithubAccessToken("gho_new_token");
+
+        assertThat(user.getGithubAccessToken()).isEqualTo("gho_new_token");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_Google_사용자는_githubAccessToken이_null이다")
+    void 기능_테스트_Google_사용자는_githubAccessToken이_null이다() {
+        User user = User.builder()
+                .providerId("google123")
+                .provider(OAuthProvider.GOOGLE)
+                .email("google@test.com")
+                .name("구글유저")
+                .role(UserRole.USER)
+                .build();
+
+        assertThat(user.getGithubAccessToken()).isNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_토큰_갱신_후_다시_갱신할_수_있다")
+    void 기능_테스트_토큰_갱신_후_다시_갱신할_수_있다() {
+        User user = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("test@test.com")
+                .name("testuser")
+                .githubAccessToken("old_token")
+                .role(UserRole.USER)
+                .build();
+
+        user.updateGithubAccessToken("new_token");
+        assertThat(user.getGithubAccessToken()).isEqualTo("new_token");
+
+        user.updateGithubAccessToken("newer_token");
+        assertThat(user.getGithubAccessToken()).isEqualTo("newer_token");
+    }
+}

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -1321,7 +1321,7 @@ class InterviewServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
         given(jobCrawlerClient.crawl("https://jobs.example.com/backend")).willReturn(crawledContent);
-        given(githubApiClient.extractGithubInfo("https://github.com/testuser")).willReturn(githubContent);
+        given(githubApiClient.extractGithubInfo(eq("https://github.com/testuser"), any())).willReturn(githubContent);
         given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
 
         // when
@@ -1330,7 +1330,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response).isNotNull();
         verify(jobCrawlerClient).crawl("https://jobs.example.com/backend");
-        verify(githubApiClient).extractGithubInfo("https://github.com/testuser");
+        verify(githubApiClient).extractGithubInfo(eq("https://github.com/testuser"), any());
     }
 
     @Test
@@ -1352,7 +1352,7 @@ class InterviewServiceImplTest {
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-        given(githubApiClient.extractGithubInfo("https://github.com/testuser")).willReturn(githubContent);
+        given(githubApiClient.extractGithubInfo(eq("https://github.com/testuser"), any())).willReturn(githubContent);
         given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
 
         // when
@@ -1360,7 +1360,7 @@ class InterviewServiceImplTest {
 
         // then
         assertThat(response).isNotNull();
-        verify(githubApiClient).extractGithubInfo("https://github.com/testuser");
+        verify(githubApiClient).extractGithubInfo(eq("https://github.com/testuser"), any());
         verify(jobCrawlerClient, org.mockito.Mockito.never()).crawl(any());
     }
 
@@ -1399,7 +1399,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response).isNotNull();
         verify(jobCrawlerClient).crawl("https://jobs.example.com/backend");
-        verify(githubApiClient, org.mockito.Mockito.never()).extractGithubInfo(any());
+        verify(githubApiClient, org.mockito.Mockito.never()).extractGithubInfo(any(), any());
     }
 
     @Test
@@ -1428,7 +1428,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response).isNotNull();
         verify(jobCrawlerClient, org.mockito.Mockito.never()).crawl(any());
-        verify(githubApiClient, org.mockito.Mockito.never()).extractGithubInfo(any());
+        verify(githubApiClient, org.mockito.Mockito.never()).extractGithubInfo(any(), any());
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -127,6 +127,8 @@ class InterviewServiceImplTest {
         InterviewProperties.Sse sse = new InterviewProperties.Sse();
         lenient().when(interviewProperties.getPrompt()).thenReturn(prompt);
         lenient().when(interviewProperties.getSse()).thenReturn(sse);
+        lenient().when(interviewProperties.getCrawlTimeoutSeconds()).thenReturn(15);
+        lenient().when(interviewProperties.getGithubTimeoutSeconds()).thenReturn(30);
 
         lenient().when(tokenEstimator.trimHistoryWithPriority(any(), anyInt()))
                 .thenAnswer(inv -> {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,3 +27,6 @@ spring:
 
 jwt:
   secret: test-jwt-secret-for-ci-minimum-256bit-length-required-padding-here
+
+encryption:
+  secret-key: test-encrypt-key!


### PR DESCRIPTION
## Summary
- User 엔티티에 `githubAccessToken` 필드 추가 (AES 암호화 저장)
- OAuth2 로그인 시 GitHub access token 자동 저장/갱신
- `GithubApiClient`에서 토큰이 있으면 `Authorization: Bearer` 헤더로 인증된 호출 (시간당 60회 → 5000회)
- Google 로그인 사용자는 토큰 없이 기존 방식으로 fallback
- `@ToString`에서 토큰 제외, `joinSafely` 타임아웃 외부화

## Test plan
- [x] GitHub 로그인 후 DB에서 `github_access_token` 컬럼에 암호화된 값 확인
- [x] GitHub URL로 면접 시작 → API 호출에 Authorization 헤더 포함 확인
- [x] Google 로그인 사용자도 면접 정상 진행 확인 (토큰 없이 fallback)
- [x] 재로그인 시 토큰 갱신 확인

Closes #68