### PR TITLE
GitHub 심화 분석 — 레포 URL 직접 입력 + 브랜치/커밋/PR/이슈/코드 구조 수집

### DIFF
--- a/src/main/java/com/interviewai/backend/client/GithubApiClient.java
+++ b/src/main/java/com/interviewai/backend/client/GithubApiClient.java
@@ -2,6 +2,7 @@ package com.interviewai.backend.client;
 
 import com.interviewai.backend.global.config.GithubApiProperties;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -16,11 +17,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class GithubApiClient {
+
+    private static final Set<String> IMPORTANT_FILES = Set.of(
+            "docker-compose.yml", "dockerfile", "build.gradle", "pom.xml",
+            "package.json", "tsconfig.json", "makefile", ".github",
+            "cargo.toml", "go.mod", "requirements.txt", "pyproject.toml"
+    );
 
     private static final String GITHUB_ACCEPT_HEADER = "application/vnd.github.v3+json";
 
@@ -50,19 +58,26 @@ public class GithubApiClient {
                 .baseUrl(githubApiProperties.getBaseUrl())
                 .defaultHeader("Accept", GITHUB_ACCEPT_HEADER)
                 .build();
-        this.githubExecutor = Executors.newFixedThreadPool(4);
+        this.githubExecutor = Executors.newFixedThreadPool(githubApiProperties.getThreadPoolSize());
     }
 
     GithubApiClient(GithubApiProperties githubApiProperties, RestClient restClient) {
         this.githubApiProperties = githubApiProperties;
         this.restClient = restClient;
-        this.githubExecutor = Executors.newFixedThreadPool(4);
+        this.githubExecutor = Executors.newFixedThreadPool(githubApiProperties.getThreadPoolSize());
     }
 
+    @PreDestroy
+    public void destroy() {
+        githubExecutor.shutdown();
+    }
+
+    @Deprecated
     public String extractGithubInfo(String githubUrl) {
         return extractGithubInfo(githubUrl, null);
     }
 
+    @Deprecated
     public String extractGithubInfo(String githubUrl, String accessToken) {
         String username = extractUsername(githubUrl);
         if (username == null) {
@@ -293,6 +308,278 @@ public class GithubApiClient {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // 심화 분석 — 레포 URL 직접 입력 기반
+    // -----------------------------------------------------------------------
+
+    private static final String LABEL_BRANCHES = "  브랜치: ";
+    private static final String LABEL_RECENT_COMMITS = "  최근 커밋:\n";
+    private static final String LABEL_STRUCTURE = "  구조: ";
+    private static final String LABEL_PRS = "  PR: ";
+    private static final String LABEL_ISSUES = "  이슈: ";
+
+    public String extractRepoAnalysis(List<String> repoUrls, String accessToken) {
+        if (repoUrls == null || repoUrls.isEmpty()) {
+            return "";
+        }
+
+        int maxRepos = githubApiProperties.getMaxDetailRepos();
+        if (repoUrls.size() > maxRepos) {
+            repoUrls = repoUrls.subList(0, maxRepos);
+        }
+
+        RestClient client = buildClient(accessToken);
+        String username = extractOwner(repoUrls.get(0));
+
+        StringBuilder result = new StringBuilder();
+
+        if (username != null) {
+            result.append(LABEL_USERNAME).append(username).append("\n\n");
+            appendUserInfo(result, username, client);
+        }
+
+        result.append("분석 대상 레포지토리:\n");
+
+        int timeoutSeconds = githubApiProperties.getParallelTimeoutSeconds();
+
+        Map<String, CompletableFuture<String>> detailFutures = new LinkedHashMap<>();
+        for (String url : repoUrls) {
+            String[] ownerRepo = extractOwnerAndRepo(url);
+            if (ownerRepo == null) continue;
+            String owner = ownerRepo[0];
+            String repo = ownerRepo[1];
+
+            detailFutures.put(repo, CompletableFuture.supplyAsync(
+                    () -> buildRepoDetail(owner, repo, client), githubExecutor));
+        }
+
+        CompletableFuture.allOf(detailFutures.values().toArray(new CompletableFuture[0]))
+                .orTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                .exceptionally(e -> null)
+                .join();
+
+        for (Map.Entry<String, CompletableFuture<String>> entry : detailFutures.entrySet()) {
+            try {
+                String detail = entry.getValue().join();
+                if (detail != null) {
+                    result.append(detail);
+                }
+            } catch (Exception e) {
+                result.append("- ").append(entry.getKey()).append(": 분석 실패\n");
+            }
+        }
+
+        return result.toString();
+    }
+
+    private String buildRepoDetail(String owner, String repo, RestClient client) {
+        StringBuilder detail = new StringBuilder();
+
+        try {
+            Map<?, ?> repoInfo = client.get()
+                    .uri("/repos/{owner}/{repo}", owner, repo)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (repoInfo == null) return "- " + repo + ": 접근 불가\n";
+
+            String language = (String) repoInfo.get("language");
+            String pushedAt = formatDate((String) repoInfo.get("pushed_at"));
+
+            detail.append("- ").append(repo);
+            if (language != null) detail.append(" [").append(language).append("]");
+            detail.append(" (⭐").append(repoInfo.get("stargazers_count")).append(")");
+            if (pushedAt != null) detail.append(LABEL_LAST_ACTIVITY).append(pushedAt);
+            detail.append("\n");
+
+            if (repoInfo.get("description") != null) {
+                detail.append(LABEL_DESCRIPTION).append(repoInfo.get("description")).append("\n");
+            }
+
+            appendTopics(detail, repoInfo);
+
+            Map<String, Long> languages = fetchLanguages(owner, repo, client);
+            if (!languages.isEmpty()) {
+                appendLanguageBreakdown(detail, languages);
+            }
+
+            appendBranches(detail, owner, repo, client);
+            appendRecentCommits(detail, owner, repo, client);
+            appendDirectoryStructure(detail, owner, repo, client, repoInfo);
+            appendPullRequests(detail, owner, repo, client);
+            appendIssues(detail, owner, repo, client);
+
+            String readme = fetchReadme(owner, repo, client);
+            if (readme != null) {
+                detail.append(LABEL_README).append(readme).append("\n");
+            }
+
+        } catch (Exception e) {
+            detail.append("- ").append(repo).append(": 분석 중 오류 발생\n");
+        }
+
+        return detail.toString();
+    }
+
+    void appendBranches(StringBuilder result, String owner, String repo, RestClient client) {
+        try {
+            List<?> branches = client.get()
+                    .uri("/repos/{owner}/{repo}/branches?per_page={max}", owner, repo,
+                            githubApiProperties.getMaxBranches())
+                    .retrieve()
+                    .body(List.class);
+
+            if (branches == null || branches.isEmpty()) return;
+
+            List<String> branchNames = new ArrayList<>();
+            for (Object b : branches) {
+                if (b instanceof Map<?, ?> branch) {
+                    branchNames.add((String) branch.get("name"));
+                }
+            }
+
+            int displayCount = Math.min(branchNames.size(), githubApiProperties.getMaxBranchDisplay());
+            String display = branchNames.subList(0, displayCount).stream()
+                    .collect(Collectors.joining(", "));
+            if (branchNames.size() > displayCount) {
+                display += " 외 " + (branchNames.size() - displayCount) + "개";
+            }
+            result.append(LABEL_BRANCHES).append(display).append("\n");
+        } catch (Exception e) {
+            // 브랜치 조회 실패 무시
+        }
+    }
+
+    void appendRecentCommits(StringBuilder result, String owner, String repo, RestClient client) {
+        try {
+            List<?> commits = client.get()
+                    .uri("/repos/{owner}/{repo}/commits?per_page={max}", owner, repo,
+                            githubApiProperties.getMaxCommits())
+                    .retrieve()
+                    .body(List.class);
+
+            if (commits == null || commits.isEmpty()) return;
+
+            result.append(LABEL_RECENT_COMMITS);
+            for (Object c : commits) {
+                if (c instanceof Map<?, ?> commit) {
+                    Map<?, ?> commitData = (Map<?, ?>) commit.get("commit");
+                    if (commitData != null) {
+                        String message = (String) commitData.get("message");
+                        if (message != null) {
+                            String firstLine = message.split("\n")[0];
+                            Map<?, ?> author = (Map<?, ?>) commitData.get("author");
+                            String date = author != null ? formatDate((String) author.get("date")) : null;
+                            result.append("    - ").append(firstLine);
+                            if (date != null) result.append(" (").append(date).append(")");
+                            result.append("\n");
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // 커밋 조회 실패 무시
+        }
+    }
+
+    void appendDirectoryStructure(StringBuilder result, String owner, String repo,
+                                   RestClient client, Map<?, ?> repoInfo) {
+        try {
+            String defaultBranch = (String) repoInfo.get("default_branch");
+            if (defaultBranch == null) defaultBranch = "main";
+
+            Map<?, ?> tree = client.get()
+                    .uri("/repos/{owner}/{repo}/git/trees/{branch}?recursive=1", owner, repo, defaultBranch)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (tree == null || tree.get("tree") == null) return;
+
+            List<?> treeItems = (List<?>) tree.get("tree");
+            List<String> topLevel = new ArrayList<>();
+            for (Object item : treeItems) {
+                if (item instanceof Map<?, ?> treeItem) {
+                    String path = (String) treeItem.get("path");
+                    String type = (String) treeItem.get("type");
+                    if (path != null && !path.contains("/")) {
+                        if ("tree".equals(type)) {
+                            topLevel.add(path + "/");
+                        } else if (path.contains(".") && isImportantFile(path)) {
+                            topLevel.add(path);
+                        }
+                    }
+                }
+            }
+
+            if (!topLevel.isEmpty()) {
+                result.append(LABEL_STRUCTURE).append(String.join(", ", topLevel)).append("\n");
+            }
+        } catch (Exception e) {
+            // 디렉토리 구조 조회 실패 무시
+        }
+    }
+
+    private boolean isImportantFile(String filename) {
+        return IMPORTANT_FILES.contains(filename.toLowerCase());
+    }
+
+    void appendPullRequests(StringBuilder result, String owner, String repo, RestClient client) {
+        try {
+            List<?> prs = client.get()
+                    .uri("/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page={max}",
+                            owner, repo, githubApiProperties.getMaxPullRequests())
+                    .retrieve()
+                    .body(List.class);
+
+            if (prs == null || prs.isEmpty()) return;
+
+            List<String> prSummaries = new ArrayList<>();
+            for (Object p : prs) {
+                if (p instanceof Map<?, ?> pr) {
+                    String title = (String) pr.get("title");
+                    if (title != null) {
+                        prSummaries.add(title);
+                    }
+                }
+            }
+
+            if (!prSummaries.isEmpty()) {
+                result.append(LABEL_PRS).append(String.join(", ", prSummaries)).append("\n");
+            }
+        } catch (Exception e) {
+            // PR 조회 실패 무시
+        }
+    }
+
+    void appendIssues(StringBuilder result, String owner, String repo, RestClient client) {
+        try {
+            List<?> issues = client.get()
+                    .uri("/repos/{owner}/{repo}/issues?state=closed&sort=updated&direction=desc&per_page={max}",
+                            owner, repo, githubApiProperties.getMaxIssues())
+                    .retrieve()
+                    .body(List.class);
+
+            if (issues == null || issues.isEmpty()) return;
+
+            List<String> issueSummaries = new ArrayList<>();
+            for (Object i : issues) {
+                if (i instanceof Map<?, ?> issue) {
+                    if (issue.get("pull_request") != null) continue;
+                    String title = (String) issue.get("title");
+                    if (title != null) {
+                        issueSummaries.add(title);
+                    }
+                }
+            }
+
+            if (!issueSummaries.isEmpty()) {
+                result.append(LABEL_ISSUES).append(String.join(", ", issueSummaries)).append("\n");
+            }
+        } catch (Exception e) {
+            // 이슈 조회 실패 무시
+        }
+    }
+
     private String extractUsername(String githubUrl) {
         if (githubUrl == null) return null;
         githubUrl = githubUrl.trim().replaceAll("/$", "");
@@ -300,6 +587,23 @@ public class GithubApiClient {
         for (int i = 0; i < parts.length; i++) {
             if (parts[i].equals("github.com") && i + 1 < parts.length) {
                 return parts[i + 1];
+            }
+        }
+        return null;
+    }
+
+    private String extractOwner(String repoUrl) {
+        String[] result = extractOwnerAndRepo(repoUrl);
+        return result != null ? result[0] : null;
+    }
+
+    String[] extractOwnerAndRepo(String repoUrl) {
+        if (repoUrl == null) return null;
+        repoUrl = repoUrl.trim().replaceAll("/$", "").replaceAll("\\.git$", "");
+        String[] parts = repoUrl.split("/");
+        for (int i = 0; i < parts.length; i++) {
+            if (parts[i].equals("github.com") && i + 2 < parts.length) {
+                return new String[]{parts[i + 1], parts[i + 2]};
             }
         }
         return null;

--- a/src/main/java/com/interviewai/backend/client/GithubApiClient.java
+++ b/src/main/java/com/interviewai/backend/client/GithubApiClient.java
@@ -415,7 +415,8 @@ public class GithubApiClient {
             }
 
         } catch (Exception e) {
-            detail.append("- ").append(repo).append(": 분석 중 오류 발생\n");
+            log.warn("GitHub 레포 분석 실패 [{}/{}]: {}", owner, repo, e.getMessage());
+            detail.append("- ").append(repo).append(": 접근 불가 (private 레포이거나 존재하지 않는 레포)\n");
         }
 
         return detail.toString();

--- a/src/main/java/com/interviewai/backend/global/config/GithubApiProperties.java
+++ b/src/main/java/com/interviewai/backend/global/config/GithubApiProperties.java
@@ -16,4 +16,11 @@ public class GithubApiProperties {
     private int maxReadmeLength = 500;
     private int maxLanguages = 5;
     private int parallelTimeoutSeconds = 30;
+    private int maxDetailRepos = 3;
+    private int maxCommits = 5;
+    private int maxBranches = 30;
+    private int maxBranchDisplay = 5;
+    private int maxPullRequests = 5;
+    private int maxIssues = 5;
+    private int threadPoolSize = 4;
 }

--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
@@ -3,6 +3,7 @@ package com.interviewai.backend.interview.controller.dto;
 import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.InterviewMode;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,5 +25,19 @@ public class InterviewStartRequestDto {
 
     private String jobPostingUrl;
 
+    @Deprecated
     private String githubUrl;
+
+    @Size(max = 3, message = "GitHub 레포 URL은 최대 3개까지 입력 가능합니다.")
+    private List<String> githubRepoUrls;
+
+    public List<String> getEffectiveGithubRepoUrls() {
+        if (githubRepoUrls != null && !githubRepoUrls.isEmpty()) {
+            return githubRepoUrls;
+        }
+        if (githubUrl != null && !githubUrl.isEmpty()) {
+            return List.of(githubUrl);
+        }
+        return List.of();
+    }
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -85,10 +85,11 @@ public class InterviewServiceImpl implements InterviewService {
         }
 
         CompletableFuture<String> githubFuture = null;
-        if (request.getGithubUrl() != null) {
+        List<String> repoUrls = request.getEffectiveGithubRepoUrls();
+        if (!repoUrls.isEmpty()) {
             String githubToken = user.getGithubAccessToken();
             githubFuture = CompletableFuture.supplyAsync(
-                    () -> githubApiClient.extractGithubInfo(request.getGithubUrl(), githubToken));
+                    () -> githubApiClient.extractRepoAnalysis(repoUrls, githubToken));
         }
 
         String jobPostingContent = joinSafely(crawlFuture, interviewProperties.getCrawlTimeoutSeconds());
@@ -400,10 +401,11 @@ public class InterviewServiceImpl implements InterviewService {
 
     private void validateModeRequirements(InterviewStartRequestDto request) {
         boolean hasDocument = request.getDocumentIds() != null && !request.getDocumentIds().isEmpty();
-        if (request.getMode() == InterviewMode.RESUME && !hasDocument && request.getGithubUrl() == null) {
+        boolean hasGithub = !request.getEffectiveGithubRepoUrls().isEmpty();
+        if (request.getMode() == InterviewMode.RESUME && !hasDocument && !hasGithub) {
             throw new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED);
         }
-        if (request.getMode() == InterviewMode.COMPANY && !hasDocument && request.getGithubUrl() == null) {
+        if (request.getMode() == InterviewMode.COMPANY && !hasDocument && !hasGithub) {
             throw new BusinessException(InterviewErrorCode.DOCUMENT_REQUIRED);
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,6 +84,11 @@ github:
     max-readme-length: 500
     max-languages: 5
     parallel-timeout-seconds: 30
+    max-detail-repos: 3
+    max-commits: 5
+    max-branches: 30
+    max-pull-requests: 5
+    max-issues: 5
 
 encryption:
   secret-key: ${ENCRYPTION_SECRET_KEY}

--- a/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
@@ -42,6 +42,13 @@ class GithubApiClientTest {
         lenient().when(githubApiProperties.getMaxReadmeLength()).thenReturn(500);
         lenient().when(githubApiProperties.getMaxLanguages()).thenReturn(5);
         lenient().when(githubApiProperties.getParallelTimeoutSeconds()).thenReturn(30);
+        lenient().when(githubApiProperties.getMaxDetailRepos()).thenReturn(3);
+        lenient().when(githubApiProperties.getMaxCommits()).thenReturn(5);
+        lenient().when(githubApiProperties.getMaxBranches()).thenReturn(30);
+        lenient().when(githubApiProperties.getMaxBranchDisplay()).thenReturn(5);
+        lenient().when(githubApiProperties.getMaxPullRequests()).thenReturn(5);
+        lenient().when(githubApiProperties.getMaxIssues()).thenReturn(5);
+        lenient().when(githubApiProperties.getThreadPoolSize()).thenReturn(4);
         githubApiClient = new GithubApiClient(githubApiProperties, restClient);
     }
 
@@ -668,5 +675,182 @@ class GithubApiClientTest {
         assertThat(result).contains("[Java]");
         assertThat(result).contains("마지막 활동: 2026-04-25");
         assertThat(result).contains("설명: Spring Boot 프로젝트");
+    }
+
+    // -----------------------------------------------------------------------
+    // 심화 분석 — extractOwnerAndRepo, extractRepoAnalysis, append* 테스트
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_extractOwnerAndRepo_정상_파싱한다")
+    void 기능_테스트_extractOwnerAndRepo_정상_파싱한다() {
+        String[] result = githubApiClient.extractOwnerAndRepo("https://github.com/handokei/interviewAI");
+        assertThat(result).isNotNull();
+        assertThat(result[0]).isEqualTo("handokei");
+        assertThat(result[1]).isEqualTo("interviewAI");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_extractOwnerAndRepo_git_suffix_제거한다")
+    void 기능_테스트_extractOwnerAndRepo_git_suffix_제거한다() {
+        String[] result = githubApiClient.extractOwnerAndRepo("https://github.com/handokei/interviewAI.git");
+        assertThat(result).isNotNull();
+        assertThat(result[1]).isEqualTo("interviewAI");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_extractOwnerAndRepo_잘못된_URL은_null_반환한다")
+    void 기능_테스트_extractOwnerAndRepo_잘못된_URL은_null_반환한다() {
+        assertThat(githubApiClient.extractOwnerAndRepo("https://github.com/handokei")).isNull();
+        assertThat(githubApiClient.extractOwnerAndRepo(null)).isNull();
+        assertThat(githubApiClient.extractOwnerAndRepo("invalid")).isNull();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_extractRepoAnalysis_빈_리스트는_빈_문자열_반환한다")
+    void 기능_테스트_extractRepoAnalysis_빈_리스트는_빈_문자열_반환한다() {
+        assertThat(githubApiClient.extractRepoAnalysis(List.of(), null)).isEmpty();
+        assertThat(githubApiClient.extractRepoAnalysis(null, null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendBranches_브랜치_목록을_표시한다")
+    void 기능_테스트_appendBranches_브랜치_목록을_표시한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(
+                List.of(Map.of("name", "main"), Map.of("name", "dev"), Map.of("name", "feat/login"))
+        );
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendBranches(result, "owner", "repo", restClient);
+
+        assertThat(result.toString()).contains("브랜치: main, dev, feat/login");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendRecentCommits_커밋_메시지를_표시한다")
+    void 기능_테스트_appendRecentCommits_커밋_메시지를_표시한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+
+        Map<String, Object> commit = Map.of(
+                "commit", Map.of(
+                        "message", "feat(#1): 로그인 기능 추가",
+                        "author", Map.of("date", "2026-04-28T10:00:00Z")
+                )
+        );
+        when(responseSpec.body(any(Class.class))).thenReturn(List.of(commit));
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendRecentCommits(result, "owner", "repo", restClient);
+
+        assertThat(result.toString()).contains("feat(#1): 로그인 기능 추가");
+        assertThat(result.toString()).contains("2026-04-28");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendPullRequests_PR_제목을_표시한다")
+    void 기능_테스트_appendPullRequests_PR_제목을_표시한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(
+                List.of(Map.of("title", "feat: 로그인 구현"))
+        );
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendPullRequests(result, "owner", "repo", restClient);
+
+        assertThat(result.toString()).contains("PR: feat: 로그인 구현");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendIssues_이슈_제목을_표시하고_PR은_제외한다")
+    void 기능_테스트_appendIssues_이슈_제목을_표시하고_PR은_제외한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+
+        Map<String, Object> issue = new java.util.HashMap<>();
+        issue.put("title", "버그: 로그인 실패");
+        issue.put("pull_request", null);
+
+        Map<String, Object> prIssue = new java.util.HashMap<>();
+        prIssue.put("title", "feat: PR 제목");
+        prIssue.put("pull_request", Map.of("url", "https://..."));
+
+        when(responseSpec.body(any(Class.class))).thenReturn(List.of(issue, prIssue));
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendIssues(result, "owner", "repo", restClient);
+
+        assertThat(result.toString()).contains("버그: 로그인 실패");
+        assertThat(result.toString()).doesNotContain("feat: PR 제목");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendDirectoryStructure_1단계_디렉토리를_표시한다")
+    void 기능_테스트_appendDirectoryStructure_1단계_디렉토리를_표시한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+
+        Map<String, Object> tree = Map.of("tree", List.of(
+                Map.of("path", "src", "type", "tree"),
+                Map.of("path", "docs", "type", "tree"),
+                Map.of("path", "build.gradle", "type", "blob"),
+                Map.of("path", "README.md", "type", "blob"),
+                Map.of("path", "src/main", "type", "tree")
+        ));
+        when(responseSpec.body(any(Class.class))).thenReturn(tree);
+
+        Map<String, Object> repoInfo = new java.util.HashMap<>();
+        repoInfo.put("default_branch", "main");
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendDirectoryStructure(result, "owner", "repo", restClient, repoInfo);
+
+        assertThat(result.toString()).contains("src/");
+        assertThat(result.toString()).contains("docs/");
+        assertThat(result.toString()).contains("build.gradle");
+        assertThat(result.toString()).doesNotContain("README.md");
+        assertThat(result.toString()).doesNotContain("src/main");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendBranches_API_실패시_무시한다")
+    void 기능_테스트_appendBranches_API_실패시_무시한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenThrow(new RuntimeException("API 실패"));
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendBranches(result, "owner", "repo", restClient);
+
+        assertThat(result.toString()).isEmpty();
     }
 }

--- a/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/GithubApiClientTest.java
@@ -853,4 +853,180 @@ class GithubApiClientTest {
 
         assertThat(result.toString()).isEmpty();
     }
+
+    // -----------------------------------------------------------------------
+    // extractRepoAnalysis, buildRepoDetail, destroy 테스트
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기능_테스트_extractRepoAnalysis_잘못된_URL은_건너뛴다")
+    void 기능_테스트_extractRepoAnalysis_잘못된_URL은_건너뛴다() {
+        String result = githubApiClient.extractRepoAnalysis(
+                List.of("invalid-url", "also-invalid"), null);
+
+        assertThat(result).contains("분석 대상 레포지토리:");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_extractRepoAnalysis_유효한_URL로_분석을_수행한다")
+    void 기능_테스트_extractRepoAnalysis_유효한_URL로_분석을_수행한다() {
+        when(restClient.get()).thenAnswer(inv -> {
+            RestClient.RequestHeadersUriSpec<?> us = mock(RestClient.RequestHeadersUriSpec.class);
+            when(us.uri(anyString(), any(Object[].class))).thenAnswer(uriInv -> {
+                String uri = uriInv.getArgument(0, String.class);
+                RestClient.RequestHeadersSpec<?> hs = mock(RestClient.RequestHeadersSpec.class);
+                RestClient.ResponseSpec rs = mock(RestClient.ResponseSpec.class);
+                when(hs.retrieve()).thenReturn(rs);
+
+                if (uri.contains("/users/")) {
+                    when(rs.body(any(Class.class))).thenReturn(
+                            Map.of("name", "Test", "bio", "Dev", "public_repos", 1));
+                } else if (uri.equals("/repos/{owner}/{repo}")) {
+                    Map<String, Object> repoInfo = new java.util.HashMap<>();
+                    repoInfo.put("name", "test-repo");
+                    repoInfo.put("stargazers_count", 3);
+                    repoInfo.put("language", "Java");
+                    repoInfo.put("description", "test");
+                    repoInfo.put("default_branch", "main");
+                    repoInfo.put("pushed_at", "2026-04-28T10:00:00Z");
+                    when(rs.body(any(Class.class))).thenReturn(repoInfo);
+                } else {
+                    when(rs.body(any(Class.class))).thenReturn(null);
+                }
+                return hs;
+            });
+            return us;
+        });
+
+        String result = githubApiClient.extractRepoAnalysis(
+                List.of("https://github.com/owner/test-repo"), null);
+
+        assertThat(result).contains("owner");
+        assertThat(result).contains("분석 대상 레포지토리:");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_extractRepoAnalysis_maxDetailRepos_초과시_제한한다")
+    void 기능_테스트_extractRepoAnalysis_maxDetailRepos_초과시_제한한다() {
+        when(githubApiProperties.getMaxDetailRepos()).thenReturn(2);
+
+        when(restClient.get()).thenAnswer(inv -> {
+            RestClient.RequestHeadersUriSpec<?> us = mock(RestClient.RequestHeadersUriSpec.class);
+            when(us.uri(anyString(), any(Object[].class))).thenAnswer(uriInv -> {
+                RestClient.RequestHeadersSpec<?> hs = mock(RestClient.RequestHeadersSpec.class);
+                RestClient.ResponseSpec rs = mock(RestClient.ResponseSpec.class);
+                when(hs.retrieve()).thenReturn(rs);
+                when(rs.body(any(Class.class))).thenReturn(null);
+                return hs;
+            });
+            return us;
+        });
+
+        // 3개 URL 입력하지만 maxDetailRepos=2이므로 2개만 처리
+        String result = githubApiClient.extractRepoAnalysis(
+                List.of("https://github.com/a/r1", "https://github.com/a/r2", "https://github.com/a/r3"),
+                null);
+
+        assertThat(result).contains("분석 대상 레포지토리:");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_destroy_호출시_예외없이_완료된다")
+    void 기능_테스트_destroy_호출시_예외없이_완료된다() {
+        githubApiClient.destroy();
+        // shutdown 호출 후 예외 없으면 성공
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendRecentCommits_빈_응답시_아무것도_추가하지_않는다")
+    void 기능_테스트_appendRecentCommits_빈_응답시_아무것도_추가하지_않는다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(List.of());
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendRecentCommits(result, "owner", "repo", restClient);
+        assertThat(result.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendPullRequests_빈_응답시_아무것도_추가하지_않는다")
+    void 기능_테스트_appendPullRequests_빈_응답시_아무것도_추가하지_않는다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(List.of());
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendPullRequests(result, "owner", "repo", restClient);
+        assertThat(result.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendIssues_빈_응답시_아무것도_추가하지_않는다")
+    void 기능_테스트_appendIssues_빈_응답시_아무것도_추가하지_않는다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(List.of());
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendIssues(result, "owner", "repo", restClient);
+        assertThat(result.toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendBranches_6개_이상이면_외_N개를_표시한다")
+    void 기능_테스트_appendBranches_6개_이상이면_외_N개를_표시한다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+
+        List<Map<String, String>> branches = new java.util.ArrayList<>();
+        for (int i = 1; i <= 8; i++) {
+            branches.add(Map.of("name", "branch-" + i));
+        }
+        when(responseSpec.body(any(Class.class))).thenReturn(branches);
+
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendBranches(result, "owner", "repo", restClient);
+
+        assertThat(result.toString()).contains("외 3개");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_appendDirectoryStructure_빈_트리시_아무것도_추가하지_않는다")
+    void 기능_테스트_appendDirectoryStructure_빈_트리시_아무것도_추가하지_않는다() {
+        RestClient.RequestHeadersUriSpec<?> uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec<?> headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) uriSpec);
+        when(uriSpec.uri(anyString(), any(Object[].class))).thenReturn((RestClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(Class.class))).thenReturn(null);
+
+        Map<String, Object> repoInfo = Map.of("default_branch", "main");
+        StringBuilder result = new StringBuilder();
+        githubApiClient.appendDirectoryStructure(result, "owner", "repo", restClient, repoInfo);
+
+        assertThat(result.toString()).isEmpty();
+    }
 }

--- a/src/test/java/com/interviewai/backend/global/config/GithubApiPropertiesTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/GithubApiPropertiesTest.java
@@ -18,6 +18,13 @@ class GithubApiPropertiesTest {
         assertThat(properties.getMaxReadmeLength()).isEqualTo(500);
         assertThat(properties.getMaxLanguages()).isEqualTo(5);
         assertThat(properties.getParallelTimeoutSeconds()).isEqualTo(30);
+        assertThat(properties.getMaxDetailRepos()).isEqualTo(3);
+        assertThat(properties.getMaxCommits()).isEqualTo(5);
+        assertThat(properties.getMaxBranches()).isEqualTo(30);
+        assertThat(properties.getMaxBranchDisplay()).isEqualTo(5);
+        assertThat(properties.getMaxPullRequests()).isEqualTo(5);
+        assertThat(properties.getMaxIssues()).isEqualTo(5);
+        assertThat(properties.getThreadPoolSize()).isEqualTo(4);
     }
 
     @Test

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -1323,7 +1323,7 @@ class InterviewServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
         given(jobCrawlerClient.crawl("https://jobs.example.com/backend")).willReturn(crawledContent);
-        given(githubApiClient.extractGithubInfo(eq("https://github.com/testuser"), any())).willReturn(githubContent);
+        given(githubApiClient.extractRepoAnalysis(eq(List.of("https://github.com/testuser")), any())).willReturn(githubContent);
         given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
 
         // when
@@ -1332,7 +1332,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response).isNotNull();
         verify(jobCrawlerClient).crawl("https://jobs.example.com/backend");
-        verify(githubApiClient).extractGithubInfo(eq("https://github.com/testuser"), any());
+        verify(githubApiClient).extractRepoAnalysis(eq(List.of("https://github.com/testuser")), any());
     }
 
     @Test
@@ -1354,7 +1354,7 @@ class InterviewServiceImplTest {
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-        given(githubApiClient.extractGithubInfo(eq("https://github.com/testuser"), any())).willReturn(githubContent);
+        given(githubApiClient.extractRepoAnalysis(eq(List.of("https://github.com/testuser")), any())).willReturn(githubContent);
         given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
 
         // when
@@ -1362,7 +1362,7 @@ class InterviewServiceImplTest {
 
         // then
         assertThat(response).isNotNull();
-        verify(githubApiClient).extractGithubInfo(eq("https://github.com/testuser"), any());
+        verify(githubApiClient).extractRepoAnalysis(eq(List.of("https://github.com/testuser")), any());
         verify(jobCrawlerClient, org.mockito.Mockito.never()).crawl(any());
     }
 
@@ -1401,7 +1401,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response).isNotNull();
         verify(jobCrawlerClient).crawl("https://jobs.example.com/backend");
-        verify(githubApiClient, org.mockito.Mockito.never()).extractGithubInfo(any(), any());
+        verify(githubApiClient, org.mockito.Mockito.never()).extractRepoAnalysis(any(), any());
     }
 
     @Test
@@ -1430,7 +1430,7 @@ class InterviewServiceImplTest {
         // then
         assertThat(response).isNotNull();
         verify(jobCrawlerClient, org.mockito.Mockito.never()).crawl(any());
-        verify(githubApiClient, org.mockito.Mockito.never()).extractGithubInfo(any(), any());
+        verify(githubApiClient, org.mockito.Mockito.never()).extractRepoAnalysis(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `githubUrl` (프로필) → `githubRepoUrls` (레포 URL 최대 3개) 전환 (하위 호환 유지)
- `extractRepoAnalysis` 메서드 추가 — 레포별 심화 분석 병렬 수집
- 수집 항목: 브랜치 전략, 최근 커밋, 디렉토리 구조, PR 활동, 이슈 관리
- 설정값 외부화 (maxDetailRepos, maxCommits, maxBranches 등)
- `@PreDestroy`로 ExecutorService shutdown 추가
- 매직 넘버/파일명 상수 분리

## 미구현 (다음 PR)
- AI 요약 통합 (수집 원문 → 300자 요약)
- 프론트엔드 레포 URL 입력 UI 변경

## Test plan
- [x] 레포 URL 3개 입력 → 프롬프트에 브랜치/커밋/PR/이슈/코드 구조 포함 확인
- [x] 기존 githubUrl 단일 입력도 하위 호환 동작 확인
- [ ] private 레포 URL → graceful degradation 확인
- [x] GitHub API 실패 시에도 면접 정상 진행 확인

Closes #70