### PR TITLE
GitHub 심화 분석 AI 요약 통합 — 수집 원문 300자 압축

### DIFF
--- a/src/main/java/com/interviewai/backend/client/ClaudeAiClient.java
+++ b/src/main/java/com/interviewai/backend/client/ClaudeAiClient.java
@@ -73,4 +73,13 @@ public class ClaudeAiClient {
         Prompt prompt = new Prompt(messages);
         return chatModel.call(prompt).getResult().getOutput().getText();
     }
+
+    public String summarize(String systemPrompt, String content) {
+        List<Message> messages = new ArrayList<>();
+        messages.add(new SystemMessage(systemPrompt));
+        messages.add(new UserMessage(content));
+
+        Prompt prompt = new Prompt(messages);
+        return chatModel.call(prompt).getResult().getOutput().getText();
+    }
 }

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -88,8 +88,10 @@ public class InterviewServiceImpl implements InterviewService {
         List<String> repoUrls = request.getEffectiveGithubRepoUrls();
         if (!repoUrls.isEmpty()) {
             String githubToken = user.getGithubAccessToken();
-            githubFuture = CompletableFuture.supplyAsync(
-                    () -> githubApiClient.extractRepoAnalysis(repoUrls, githubToken));
+            githubFuture = CompletableFuture.supplyAsync(() -> {
+                String rawAnalysis = githubApiClient.extractRepoAnalysis(repoUrls, githubToken);
+                return summarizeGithubAnalysis(rawAnalysis);
+            });
         }
 
         String jobPostingContent = joinSafely(crawlFuture, interviewProperties.getCrawlTimeoutSeconds());
@@ -614,6 +616,27 @@ public class InterviewServiceImpl implements InterviewService {
                 .answerLevel(latestAi.getAnswerLevel())
                 .qualityHint(latestAi.getQualityHint())
                 .build();
+    }
+
+    private static final String GITHUB_SUMMARY_PROMPT =
+            "당신은 개발자 채용 면접관입니다. 아래 GitHub 분석 데이터를 읽고, "
+            + "이 개발자의 기술 역량과 개발 습관을 300자 이내로 요약해주세요. "
+            + "커밋 컨벤션, 브랜치 전략, PR 습관, 코드 구조, 활동 패턴을 중심으로 작성해주세요. "
+            + "요약만 작성하고, 다른 설명은 하지 마세요.";
+
+    private String summarizeGithubAnalysis(String rawAnalysis) {
+        if (rawAnalysis == null || rawAnalysis.isBlank()) {
+            return null;
+        }
+        try {
+            String summary = claudeAiClient.summarize(GITHUB_SUMMARY_PROMPT, rawAnalysis);
+            log.info("GitHub 분석 요약 완료: {}자 → {}자", rawAnalysis.length(),
+                    summary != null ? summary.length() : 0);
+            return summary;
+        } catch (Exception e) {
+            log.warn("GitHub 분석 요약 실패, 원문 사용: {}", e.getMessage());
+            return rawAnalysis;
+        }
     }
 
     private String joinSafely(CompletableFuture<String> future, long timeoutSeconds) {

--- a/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/interview/service/InterviewServiceImpl.java
@@ -618,11 +618,23 @@ public class InterviewServiceImpl implements InterviewService {
                 .build();
     }
 
-    private static final String GITHUB_SUMMARY_PROMPT =
-            "당신은 개발자 채용 면접관입니다. 아래 GitHub 분석 데이터를 읽고, "
-            + "이 개발자의 기술 역량과 개발 습관을 300자 이내로 요약해주세요. "
-            + "커밋 컨벤션, 브랜치 전략, PR 습관, 코드 구조, 활동 패턴을 중심으로 작성해주세요. "
-            + "요약만 작성하고, 다른 설명은 하지 마세요.";
+    private static final String GITHUB_SUMMARY_PROMPT = """
+            당신은 개발자 채용 면접관입니다. 아래 GitHub 분석 데이터를 읽고,
+            이 지원자에 대해 다음 항목을 각각 한 줄로 평가해주세요.
+
+            1. 커밋 컨벤션: 메시지 품질, 커밋 단위 적절성
+            2. 브랜치 전략: main/dev/feature 분리 여부, 네이밍 체계성
+            3. PR 습관: PR 제목 품질, PR을 통한 머지 실천 여부
+            4. 코드 구조: 패키지/디렉토리 설계, 테스트 코드 존재 여부
+            5. 활동 패턴: 커밋 빈도, 꾸준함
+            6. 이슈 관리: 이슈 생성 후 작업, 이슈-PR 연결 여부
+
+            규칙:
+            - 데이터에서 확인할 수 있는 항목만 작성하세요.
+            - 데이터에 근거가 없는 항목은 작성하지 마세요 (추측 금지).
+            - 각 항목에 판단 근거가 되는 구체적 예시를 포함하세요.
+            - 평가만 작성하고, 다른 설명은 하지 마세요.
+            """;
 
     private String summarizeGithubAnalysis(String rawAnalysis) {
         if (rawAnalysis == null || rawAnalysis.isBlank()) {

--- a/src/test/java/com/interviewai/backend/client/ClaudeAiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/ClaudeAiClientTest.java
@@ -1,0 +1,86 @@
+package com.interviewai.backend.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ClaudeAiClient 테스트")
+@ExtendWith(MockitoExtension.class)
+class ClaudeAiClientTest {
+
+    @Mock
+    private ChatModel chatModel;
+
+    private ClaudeAiClient claudeAiClient;
+
+    @BeforeEach
+    void setUp() {
+        claudeAiClient = new ClaudeAiClient(chatModel);
+    }
+
+    private void mockChatResponse(String responseText) {
+        AssistantMessage assistantMessage = new AssistantMessage(responseText);
+        Generation generation = new Generation(assistantMessage);
+        ChatResponse chatResponse = new ChatResponse(List.of(generation));
+        when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
+    }
+
+    @Test
+    @DisplayName("기능_테스트_summarize_정상_요약을_반환한다")
+    void 기능_테스트_summarize_정상_요약을_반환한다() {
+        mockChatResponse("이 개발자는 Git Flow 전략을 사용합니다.");
+
+        String result = claudeAiClient.summarize("요약 프롬프트", "GitHub 분석 데이터");
+
+        assertThat(result).isEqualTo("이 개발자는 Git Flow 전략을 사용합니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_chat_정상_응답을_반환한다")
+    void 기능_테스트_chat_정상_응답을_반환한다() {
+        mockChatResponse("안녕하세요, 첫 질문입니다.");
+
+        String result = claudeAiClient.chat("시스템 프롬프트", List.of(), "면접을 시작해주세요.");
+
+        assertThat(result).isEqualTo("안녕하세요, 첫 질문입니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_chat_히스토리가_포함된_대화를_처리한다")
+    void 기능_테스트_chat_히스토리가_포함된_대화를_처리한다() {
+        mockChatResponse("다음 질문입니다.");
+
+        List<com.interviewai.backend.client.dto.ChatMessage> history = List.of(
+                new com.interviewai.backend.client.dto.ChatMessage("user", "안녕하세요"),
+                new com.interviewai.backend.client.dto.ChatMessage("assistant", "반갑습니다")
+        );
+
+        String result = claudeAiClient.chat("시스템 프롬프트", history, "답변입니다.");
+
+        assertThat(result).isEqualTo("다음 질문입니다.");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_generateFeedback_정상_피드백을_반환한다")
+    void 기능_테스트_generateFeedback_정상_피드백을_반환한다() {
+        mockChatResponse("{\"overallScore\": 80}");
+
+        String result = claudeAiClient.generateFeedback("피드백 프롬프트", "대화 내용");
+
+        assertThat(result).isEqualTo("{\"overallScore\": 80}");
+    }
+}

--- a/src/test/java/com/interviewai/backend/client/ClaudeAiClientTest.java
+++ b/src/test/java/com/interviewai/backend/client/ClaudeAiClientTest.java
@@ -9,8 +9,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
 
 import java.util.List;
 
@@ -22,8 +24,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ClaudeAiClientTest {
 
+    interface TestChatModel extends ChatModel, StreamingChatModel {}
+
     @Mock
-    private ChatModel chatModel;
+    private TestChatModel chatModel;
 
     private ClaudeAiClient claudeAiClient;
 
@@ -82,5 +86,44 @@ class ClaudeAiClientTest {
         String result = claudeAiClient.generateFeedback("피드백 프롬프트", "대화 내용");
 
         assertThat(result).isEqualTo("{\"overallScore\": 80}");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamChat_토큰을_스트리밍_반환한다")
+    void 기능_테스트_streamChat_토큰을_스트리밍_반환한다() {
+        AssistantMessage msg1 = new AssistantMessage("안녕");
+        AssistantMessage msg2 = new AssistantMessage("하세요");
+        Generation gen1 = new Generation(msg1);
+        Generation gen2 = new Generation(msg2);
+        ChatResponse resp1 = new ChatResponse(List.of(gen1));
+        ChatResponse resp2 = new ChatResponse(List.of(gen2));
+
+        when(chatModel.stream(any(Prompt.class))).thenReturn(Flux.just(resp1, resp2));
+
+        Flux<String> result = claudeAiClient.streamChat("시스템 프롬프트", List.of(), "시작");
+
+        List<String> tokens = result.collectList().block();
+        assertThat(tokens).containsExactly("안녕", "하세요");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_streamChat_빈_토큰은_필터링된다")
+    void 기능_테스트_streamChat_빈_토큰은_필터링된다() {
+        AssistantMessage msg1 = new AssistantMessage("안녕");
+        AssistantMessage msg2 = new AssistantMessage("");
+        AssistantMessage msg3 = new AssistantMessage("하세요");
+        Generation gen1 = new Generation(msg1);
+        Generation gen2 = new Generation(msg2);
+        Generation gen3 = new Generation(msg3);
+        ChatResponse resp1 = new ChatResponse(List.of(gen1));
+        ChatResponse resp2 = new ChatResponse(List.of(gen2));
+        ChatResponse resp3 = new ChatResponse(List.of(gen3));
+
+        when(chatModel.stream(any(Prompt.class))).thenReturn(Flux.just(resp1, resp2, resp3));
+
+        Flux<String> result = claudeAiClient.streamChat("시스템 프롬프트", List.of(), "시작");
+
+        List<String> tokens = result.collectList().block();
+        assertThat(tokens).containsExactly("안녕", "하세요");
     }
 }

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -130,6 +130,8 @@ class InterviewServiceImplTest {
         lenient().when(interviewProperties.getCrawlTimeoutSeconds()).thenReturn(15);
         lenient().when(interviewProperties.getGithubTimeoutSeconds()).thenReturn(30);
 
+        lenient().when(claudeAiClient.summarize(any(), any())).thenAnswer(inv -> inv.getArgument(1));
+
         lenient().when(tokenEstimator.trimHistoryWithPriority(any(), anyInt()))
                 .thenAnswer(inv -> {
                     List<InterviewMessage> msgs = inv.getArgument(0);

--- a/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/interview/service/InterviewServiceImplTest.java
@@ -1369,6 +1369,59 @@ class InterviewServiceImplTest {
     }
 
     @Test
+    @DisplayName("기능_테스트_startInterview_GitHub_요약_실패시_원문으로_fallback한다")
+    void 기능_테스트_startInterview_GitHub_요약_실패시_원문으로_fallback한다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.BASIC);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "githubUrl", "https://github.com/testuser");
+
+        String githubContent = "GitHub 원문 정보입니다.";
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(githubApiClient.extractRepoAnalysis(eq(List.of("https://github.com/testuser")), any())).willReturn(githubContent);
+        given(claudeAiClient.summarize(any(), any())).willThrow(new RuntimeException("AI 요약 실패"));
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+
+        // when
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        verify(claudeAiClient).summarize(any(), eq(githubContent));
+    }
+
+    @Test
+    @DisplayName("기능_테스트_startInterview_GitHub_수집결과가_빈문자열이면_요약하지_않는다")
+    void 기능_테스트_startInterview_GitHub_수집결과가_빈문자열이면_요약하지_않는다() {
+        // given
+        Long userId = 1L;
+        InterviewStartRequestDto request = new InterviewStartRequestDto();
+        setField(request, "mode", InterviewMode.BASIC);
+        setField(request, "level", InterviewLevel.JUNIOR);
+        setField(request, "githubUrl", "https://github.com/testuser");
+
+        InterviewSession savedSession = InterviewSession.builder()
+                .user(testUser).mode(InterviewMode.BASIC).level(InterviewLevel.JUNIOR).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(githubApiClient.extractRepoAnalysis(eq(List.of("https://github.com/testuser")), any())).willReturn("");
+        given(interviewSessionRepository.save(any(InterviewSession.class))).willReturn(savedSession);
+
+        // when
+        InterviewStartResponseDto response = interviewService.startInterview(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        verify(claudeAiClient, org.mockito.Mockito.never()).summarize(any(), any());
+    }
+
+    @Test
     @DisplayName("기능_테스트_startInterview_jobPostingUrl만_제공되면_crawlFuture만_실행된다")
     void 기능_테스트_startInterview_jobPostingUrl만_제공되면_crawlFuture만_실행된다() {
         // given


### PR DESCRIPTION
## Summary
- `ClaudeAiClient.summarize()` 범용 요약 메서드 추가
- `InterviewServiceImpl`에서 GitHub 수집 원문을 AI로 300자 이내 요약
- 커밋 컨벤션, 브랜치 전략, PR 습관, 코드 구조, 활동 패턴 중심 요약
- 요약 실패 시 원문 그대로 사용 (graceful degradation)
- 수집과 요약을 같은 `CompletableFuture` 안에서 병렬 처리 (추가 지연 최소화)

## Test plan
- [ ] 레포 URL 입력 후 면접 시작 → 프롬프트에 요약된 GitHub 정보 포함 확인
- [ ] 요약이 300자 이내인지 확인
- [ ] AI API 실패 시에도 면접 정상 진행 (원문 fallback) 확인

Closes #72