### PR TITLE
면접 시작 시 직군(jobTitle) 선택 필수화

### DIFF
--- a/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
+++ b/src/main/java/com/interviewai/backend/interview/controller/dto/InterviewStartRequestDto.java
@@ -2,6 +2,7 @@ package com.interviewai.backend.interview.controller.dto;
 
 import com.interviewai.backend.interview.enums.InterviewLevel;
 import com.interviewai.backend.interview.enums.InterviewMode;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class InterviewStartRequestDto {
     @NotNull(message = "면접 레벨은 필수입니다.")
     private InterviewLevel level;
 
+    @NotBlank(message = "직군은 필수입니다.")
     private String jobTitle;
 
     private List<Long> documentIds;

--- a/src/test/java/com/interviewai/backend/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/interviewai/backend/interview/controller/InterviewControllerTest.java
@@ -107,6 +107,23 @@ class InterviewControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("예외_테스트_면접_시작_jobTitle_누락_시_400을_반환한다")
+    void 예외_테스트_면접_시작_jobTitle_누락_시_400을_반환한다() throws Exception {
+        String noJobTitle = """
+                {
+                  "mode": "BASIC",
+                  "level": "JUNIOR"
+                }
+                """;
+
+        mockMvc.perform(post("/api/interviews")
+                        .with(authentication(auth))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(noJobTitle))
+                .andExpect(status().isBadRequest());
+    }
+
     // -------------------------------------------------------------------------
     // POST /api/interviews/{sessionId}/first-question/stream — streamFirstQuestion
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `InterviewStartRequestDto.jobTitle`에 `@NotBlank` 검증 추가
- jobTitle 누락 시 400 Bad Request 반환 테스트 추가

## Test plan
- [x] `./gradlew test` 통과
- [x] `./gradlew build` 통과
- [x] jobTitle 없이 요청 시 400 반환 확인
- [x] jobTitle 포함 정상 요청 시 200 반환 확인

Closes #75