### PR TITLE
feat(#77): 이메일/비밀번호 회원가입 및 로그인 기능 추가

### DIFF
--- a/src/main/java/com/interviewai/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/interviewai/backend/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.interviewai.backend.auth.controller;
 
+import com.interviewai.backend.auth.controller.dto.LoginRequestDto;
 import com.interviewai.backend.auth.controller.dto.RefreshTokenRequestDto;
+import com.interviewai.backend.auth.controller.dto.SignupRequestDto;
 import com.interviewai.backend.auth.controller.dto.TokenResponseDto;
 import com.interviewai.backend.auth.service.AuthService;
 import com.interviewai.backend.global.common.response.ApiResponse;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +24,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Operation(summary = "이메일 회원가입")
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> signup(
+            @Valid @RequestBody SignupRequestDto request) {
+        TokenResponseDto response = TokenResponseDto.from(
+                authService.signup(request.getEmail(), request.getPassword(),
+                        request.getConfirmPassword(), request.getName()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "이메일 로그인")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> login(
+            @Valid @RequestBody LoginRequestDto request) {
+        TokenResponseDto response = TokenResponseDto.from(
+                authService.login(request.getEmail(), request.getPassword()));
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 
     @Operation(summary = "토큰 갱신")
     @PostMapping("/refresh")

--- a/src/main/java/com/interviewai/backend/auth/controller/dto/LoginRequestDto.java
+++ b/src/main/java/com/interviewai/backend/auth/controller/dto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package com.interviewai.backend.auth.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/interviewai/backend/auth/controller/dto/SignupRequestDto.java
+++ b/src/main/java/com/interviewai/backend/auth/controller/dto/SignupRequestDto.java
@@ -1,0 +1,30 @@
+package com.interviewai.backend.auth.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*]{8,20}$",
+            message = "비밀번호는 영문과 숫자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
+    private String confirmPassword;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, max = 20, message = "이름은 2자 이상 20자 이하여야 합니다.")
+    private String name;
+}

--- a/src/main/java/com/interviewai/backend/auth/enums/AuthErrorCode.java
+++ b/src/main/java/com/interviewai/backend/auth/enums/AuthErrorCode.java
@@ -12,7 +12,9 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_TOKEN("A001", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_TOKEN("A002", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_NOT_FOUND("A003", "리프레시 토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    UNAUTHORIZED("A004", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED);
+    UNAUTHORIZED("A004", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    CONFIRM_PASSWORD_MISMATCH("A005", "비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CREDENTIALS("A006", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/auth/service/AuthService.java
+++ b/src/main/java/com/interviewai/backend/auth/service/AuthService.java
@@ -5,4 +5,8 @@ import com.interviewai.backend.auth.service.dto.AuthTokenServiceDto;
 public interface AuthService {
 
     AuthTokenServiceDto refreshToken(String refreshToken);
+
+    AuthTokenServiceDto signup(String email, String password, String confirmPassword, String name);
+
+    AuthTokenServiceDto login(String email, String password);
 }

--- a/src/main/java/com/interviewai/backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/auth/service/AuthServiceImpl.java
@@ -4,10 +4,13 @@ import com.interviewai.backend.auth.enums.AuthErrorCode;
 import com.interviewai.backend.auth.service.dto.AuthTokenServiceDto;
 import com.interviewai.backend.global.common.exception.BusinessException;
 import com.interviewai.backend.global.config.jwt.JwtProvider;
+import com.interviewai.backend.user.enums.OAuthProvider;
 import com.interviewai.backend.user.enums.UserErrorCode;
+import com.interviewai.backend.user.enums.UserRole;
 import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,45 @@ public class AuthServiceImpl implements AuthService {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public AuthTokenServiceDto signup(String email, String password, String confirmPassword, String name) {
+        if (!password.equals(confirmPassword)) {
+            throw new BusinessException(AuthErrorCode.CONFIRM_PASSWORD_MISMATCH);
+        }
+
+        userRepository.findByEmail(email).ifPresent(existing -> {
+            throw new BusinessException(UserErrorCode.EMAIL_ALREADY_REGISTERED);
+        });
+
+        User user = userRepository.save(User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email(email)
+                .name(name)
+                .password(passwordEncoder.encode(password))
+                .role(UserRole.USER)
+                .build());
+
+        return generateTokenPair(user);
+    }
+
+    @Override
+    public AuthTokenServiceDto login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
+
+        if (user.getProvider() != OAuthProvider.LOCAL || user.getPassword() == null) {
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return generateTokenPair(user);
+    }
 
     @Override
     public AuthTokenServiceDto refreshToken(String refreshToken) {
@@ -29,12 +71,16 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
-        String newRefreshToken = jwtProvider.generateRefreshToken(user.getId());
+        return generateTokenPair(user);
+    }
+
+    private AuthTokenServiceDto generateTokenPair(User user) {
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
         return AuthTokenServiceDto.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/interviewai/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/interviewai/backend/global/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -52,6 +54,11 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserService.java
@@ -62,6 +62,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return switch (provider) {
             case GITHUB -> new GithubOAuth2UserInfo(attributes);
             case GOOGLE -> new GoogleOAuth2UserInfo(attributes);
+            case LOCAL -> throw new OAuth2AuthenticationException("LOCAL provider는 OAuth2 로그인을 지원하지 않습니다.");
         };
     }
 }

--- a/src/main/java/com/interviewai/backend/user/enums/OAuthProvider.java
+++ b/src/main/java/com/interviewai/backend/user/enums/OAuthProvider.java
@@ -1,5 +1,5 @@
 package com.interviewai.backend.user.enums;
 
 public enum OAuthProvider {
-    GITHUB, GOOGLE
+    GITHUB, GOOGLE, LOCAL
 }

--- a/src/main/java/com/interviewai/backend/user/enums/UserErrorCode.java
+++ b/src/main/java/com/interviewai/backend/user/enums/UserErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    EMAIL_ALREADY_REGISTERED("U002", "이미 등록된 이메일입니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/user/model/User.java
+++ b/src/main/java/com/interviewai/backend/user/model/User.java
@@ -13,14 +13,13 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"githubAccessToken"})
+@ToString(exclude = {"githubAccessToken", "password"})
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String providerId;
 
     @Enumerated(EnumType.STRING)
@@ -34,6 +33,8 @@ public class User {
     private String name;
 
     private String profileImageUrl;
+
+    private String password;
 
     @Convert(converter = com.interviewai.backend.global.config.EncryptedStringConverter.class)
     private String githubAccessToken;
@@ -52,12 +53,13 @@ public class User {
 
     @Builder
     public User(String providerId, OAuthProvider provider, String email, String name,
-                String profileImageUrl, String githubAccessToken, UserRole role) {
+                String profileImageUrl, String password, String githubAccessToken, UserRole role) {
         this.providerId = providerId;
         this.provider = provider;
         this.email = email;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+        this.password = password;
         this.githubAccessToken = githubAccessToken;
         this.role = role;
     }

--- a/src/test/java/com/interviewai/backend/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/auth/service/AuthServiceImplTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -31,6 +32,9 @@ class AuthServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("기능_테스트_유효한_리프레시_토큰으로_새_토큰을_발급한다")
@@ -89,6 +93,138 @@ class AuthServiceImplTest {
         assertThatThrownBy(() -> authService.refreshToken(refreshToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("사용자");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_이메일_회원가입에_성공한다")
+    void 기능_테스트_이메일_회원가입에_성공한다() {
+        // given
+        String email = "user@test.com";
+        String password = "password123";
+        String name = "테스트유저";
+        String encodedPassword = "encoded_password";
+
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        given(passwordEncoder.encode(password)).willReturn(encodedPassword);
+        given(userRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(jwtProvider.generateAccessToken(any(), any())).willReturn("access.token");
+        given(jwtProvider.generateRefreshToken(any())).willReturn("refresh.token");
+
+        // when
+        AuthTokenServiceDto result = authService.signup(email, password, password, name);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("access.token");
+        assertThat(result.getRefreshToken()).isEqualTo("refresh.token");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_비밀번호_확인이_일치하지_않으면_예외가_발생한다")
+    void 예외_테스트_비밀번호_확인이_일치하지_않으면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> authService.signup("user@test.com", "password123", "different", "유저"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("비밀번호 확인이 일치하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_이메일이_중복되면_예외가_발생한다")
+    void 예외_테스트_이메일이_중복되면_예외가_발생한다() {
+        // given
+        String email = "existing@test.com";
+        User existingUser = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email(email)
+                .name("기존유저")
+                .role(UserRole.USER)
+                .build();
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(existingUser));
+
+        // when & then
+        assertThatThrownBy(() -> authService.signup(email, "password123", "password123", "새유저"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이미 등록된 이메일");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_이메일_로그인에_성공한다")
+    void 기능_테스트_이메일_로그인에_성공한다() {
+        // given
+        String email = "user@test.com";
+        String password = "password123";
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email(email)
+                .name("테스트유저")
+                .password("encoded_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(password, "encoded_password")).willReturn(true);
+        given(jwtProvider.generateAccessToken(any(), any())).willReturn("access.token");
+        given(jwtProvider.generateRefreshToken(any())).willReturn("refresh.token");
+
+        // when
+        AuthTokenServiceDto result = authService.login(email, password);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("access.token");
+        assertThat(result.getRefreshToken()).isEqualTo("refresh.token");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_이메일로_로그인하면_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_이메일로_로그인하면_예외가_발생한다() {
+        // given
+        given(userRepository.findByEmail("none@test.com")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("none@test.com", "password123"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_비밀번호가_틀리면_예외가_발생한다")
+    void 예외_테스트_비밀번호가_틀리면_예외가_발생한다() {
+        // given
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email("user@test.com")
+                .name("테스트유저")
+                .password("encoded_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findByEmail("user@test.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong_password", "encoded_password")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("user@test.com", "wrong_password"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_OAuth_사용자가_이메일_로그인을_시도하면_예외가_발생한다")
+    void 예외_테스트_OAuth_사용자가_이메일_로그인을_시도하면_예외가_발생한다() {
+        // given
+        User oauthUser = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("github@test.com")
+                .name("깃허브유저")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findByEmail("github@test.com")).willReturn(Optional.of(oauthUser));
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("github@test.com", "password123"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
     }
 
     // Mockito argument matchers helper


### PR DESCRIPTION
## Summary
- OAuth2 전용이던 인증 시스템에 이메일/비밀번호 기반 회원가입·로그인 추가
- `OAuthProvider.LOCAL` 도입으로 가입 경로를 명확히 구분
- BCrypt 해싱, 비밀번호 복잡도 검증, 계정 존재 여부 유출 방지 적용

## Test plan
- [ ] `POST /api/auth/signup` — 정상 가입 시 201 + accessToken/refreshToken 반환
- [ ] 같은 이메일로 재가입 시도 → 409 Conflict
- [ ] 비밀번호 8자 미만 또는 영문/숫자 미포함 → 400 Validation 에러
- [ ] confirmPassword 불일치 → 400
- [ ] `POST /api/auth/login` — 정상 로그인 시 200 + 토큰 반환
- [ ] 틀린 비밀번호 / 미존재 이메일 / OAuth 사용자 → 401 (동일 메시지)
- [ ] 기존 GitHub/Google OAuth2 로그인 정상 동작 확인

Closes #77