### PR TITLE
feat(#79): 비밀번호 변경 시 현재 비밀번호 확인 기능 추가

### DIFF
--- a/src/main/java/com/interviewai/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/interviewai/backend/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.interviewai.backend.auth.controller;
 
+import com.interviewai.backend.auth.controller.dto.LoginRequestDto;
 import com.interviewai.backend.auth.controller.dto.RefreshTokenRequestDto;
+import com.interviewai.backend.auth.controller.dto.SignupRequestDto;
 import com.interviewai.backend.auth.controller.dto.TokenResponseDto;
 import com.interviewai.backend.auth.service.AuthService;
 import com.interviewai.backend.global.common.response.ApiResponse;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +24,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Operation(summary = "이메일 회원가입")
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> signup(
+            @Valid @RequestBody SignupRequestDto request) {
+        TokenResponseDto response = TokenResponseDto.from(
+                authService.signup(request.getEmail(), request.getPassword(),
+                        request.getConfirmPassword(), request.getName()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "이메일 로그인")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> login(
+            @Valid @RequestBody LoginRequestDto request) {
+        TokenResponseDto response = TokenResponseDto.from(
+                authService.login(request.getEmail(), request.getPassword()));
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 
     @Operation(summary = "토큰 갱신")
     @PostMapping("/refresh")

--- a/src/main/java/com/interviewai/backend/auth/controller/dto/LoginRequestDto.java
+++ b/src/main/java/com/interviewai/backend/auth/controller/dto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package com.interviewai.backend.auth.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/interviewai/backend/auth/controller/dto/SignupRequestDto.java
+++ b/src/main/java/com/interviewai/backend/auth/controller/dto/SignupRequestDto.java
@@ -1,0 +1,30 @@
+package com.interviewai.backend.auth.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*]{8,20}$",
+            message = "비밀번호는 영문과 숫자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
+    private String confirmPassword;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, max = 20, message = "이름은 2자 이상 20자 이하여야 합니다.")
+    private String name;
+}

--- a/src/main/java/com/interviewai/backend/auth/enums/AuthErrorCode.java
+++ b/src/main/java/com/interviewai/backend/auth/enums/AuthErrorCode.java
@@ -12,7 +12,9 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_TOKEN("A001", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_TOKEN("A002", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_NOT_FOUND("A003", "리프레시 토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    UNAUTHORIZED("A004", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED);
+    UNAUTHORIZED("A004", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    CONFIRM_PASSWORD_MISMATCH("A005", "비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CREDENTIALS("A006", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/auth/service/AuthService.java
+++ b/src/main/java/com/interviewai/backend/auth/service/AuthService.java
@@ -5,4 +5,8 @@ import com.interviewai.backend.auth.service.dto.AuthTokenServiceDto;
 public interface AuthService {
 
     AuthTokenServiceDto refreshToken(String refreshToken);
+
+    AuthTokenServiceDto signup(String email, String password, String confirmPassword, String name);
+
+    AuthTokenServiceDto login(String email, String password);
 }

--- a/src/main/java/com/interviewai/backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/auth/service/AuthServiceImpl.java
@@ -4,10 +4,13 @@ import com.interviewai.backend.auth.enums.AuthErrorCode;
 import com.interviewai.backend.auth.service.dto.AuthTokenServiceDto;
 import com.interviewai.backend.global.common.exception.BusinessException;
 import com.interviewai.backend.global.config.jwt.JwtProvider;
+import com.interviewai.backend.user.enums.OAuthProvider;
 import com.interviewai.backend.user.enums.UserErrorCode;
+import com.interviewai.backend.user.enums.UserRole;
 import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,45 @@ public class AuthServiceImpl implements AuthService {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public AuthTokenServiceDto signup(String email, String password, String confirmPassword, String name) {
+        if (!password.equals(confirmPassword)) {
+            throw new BusinessException(AuthErrorCode.CONFIRM_PASSWORD_MISMATCH);
+        }
+
+        userRepository.findByEmail(email).ifPresent(existing -> {
+            throw new BusinessException(UserErrorCode.EMAIL_ALREADY_REGISTERED);
+        });
+
+        User user = userRepository.save(User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email(email)
+                .name(name)
+                .password(passwordEncoder.encode(password))
+                .role(UserRole.USER)
+                .build());
+
+        return generateTokenPair(user);
+    }
+
+    @Override
+    public AuthTokenServiceDto login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
+
+        if (user.getProvider() != OAuthProvider.LOCAL || user.getPassword() == null) {
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return generateTokenPair(user);
+    }
 
     @Override
     public AuthTokenServiceDto refreshToken(String refreshToken) {
@@ -29,12 +71,16 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
-        String newRefreshToken = jwtProvider.generateRefreshToken(user.getId());
+        return generateTokenPair(user);
+    }
+
+    private AuthTokenServiceDto generateTokenPair(User user) {
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
         return AuthTokenServiceDto.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/interviewai/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/interviewai/backend/global/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -52,6 +54,11 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/interviewai/backend/global/config/oauth/CustomOAuth2UserService.java
@@ -62,6 +62,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return switch (provider) {
             case GITHUB -> new GithubOAuth2UserInfo(attributes);
             case GOOGLE -> new GoogleOAuth2UserInfo(attributes);
+            case LOCAL -> throw new OAuth2AuthenticationException("LOCAL provider는 OAuth2 로그인을 지원하지 않습니다.");
         };
     }
 }

--- a/src/main/java/com/interviewai/backend/user/controller/UserController.java
+++ b/src/main/java/com/interviewai/backend/user/controller/UserController.java
@@ -1,14 +1,18 @@
 package com.interviewai.backend.user.controller;
 
 import com.interviewai.backend.global.common.response.ApiResponse;
+import com.interviewai.backend.user.controller.dto.ChangePasswordRequestDto;
 import com.interviewai.backend.user.controller.dto.UserProfileResponseDto;
 import com.interviewai.backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +29,15 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserProfileResponseDto>> getMyProfile(
             @AuthenticationPrincipal Long userId) {
         return ResponseEntity.ok(ApiResponse.ok(userService.findUserProfile(userId)));
+    }
+
+    @Operation(summary = "비밀번호 변경")
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ChangePasswordRequestDto request) {
+        userService.changePassword(userId, request.getCurrentPassword(),
+                request.getNewPassword(), request.getConfirmNewPassword());
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/com/interviewai/backend/user/controller/dto/ChangePasswordRequestDto.java
+++ b/src/main/java/com/interviewai/backend/user/controller/dto/ChangePasswordRequestDto.java
@@ -1,0 +1,24 @@
+package com.interviewai.backend.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChangePasswordRequestDto {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*]{8,20}$",
+            message = "비밀번호는 영문과 숫자를 포함해야 합니다.")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
+    private String confirmNewPassword;
+}

--- a/src/main/java/com/interviewai/backend/user/enums/OAuthProvider.java
+++ b/src/main/java/com/interviewai/backend/user/enums/OAuthProvider.java
@@ -1,5 +1,5 @@
 package com.interviewai.backend.user.enums;
 
 public enum OAuthProvider {
-    GITHUB, GOOGLE
+    GITHUB, GOOGLE, LOCAL
 }

--- a/src/main/java/com/interviewai/backend/user/enums/UserErrorCode.java
+++ b/src/main/java/com/interviewai/backend/user/enums/UserErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    EMAIL_ALREADY_REGISTERED("U002", "이미 등록된 이메일입니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/user/enums/UserErrorCode.java
+++ b/src/main/java/com/interviewai/backend/user/enums/UserErrorCode.java
@@ -10,7 +10,11 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    EMAIL_ALREADY_REGISTERED("U002", "이미 등록된 이메일입니다.", HttpStatus.CONFLICT);
+    EMAIL_ALREADY_REGISTERED("U002", "이미 등록된 이메일입니다.", HttpStatus.CONFLICT),
+    PASSWORD_CHANGE_NOT_SUPPORTED("U003", "비밀번호 변경을 지원하지 않는 계정입니다.", HttpStatus.BAD_REQUEST),
+    CURRENT_PASSWORD_MISMATCH("U004", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    CONFIRM_PASSWORD_MISMATCH("U005", "비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NEW_PASSWORD_SAME_AS_CURRENT("U006", "새 비밀번호가 현재 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/interviewai/backend/user/model/User.java
+++ b/src/main/java/com/interviewai/backend/user/model/User.java
@@ -13,14 +13,13 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"githubAccessToken"})
+@ToString(exclude = {"githubAccessToken", "password"})
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String providerId;
 
     @Enumerated(EnumType.STRING)
@@ -34,6 +33,8 @@ public class User {
     private String name;
 
     private String profileImageUrl;
+
+    private String password;
 
     @Convert(converter = com.interviewai.backend.global.config.EncryptedStringConverter.class)
     private String githubAccessToken;
@@ -52,12 +53,13 @@ public class User {
 
     @Builder
     public User(String providerId, OAuthProvider provider, String email, String name,
-                String profileImageUrl, String githubAccessToken, UserRole role) {
+                String profileImageUrl, String password, String githubAccessToken, UserRole role) {
         this.providerId = providerId;
         this.provider = provider;
         this.email = email;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+        this.password = password;
         this.githubAccessToken = githubAccessToken;
         this.role = role;
     }

--- a/src/main/java/com/interviewai/backend/user/model/User.java
+++ b/src/main/java/com/interviewai/backend/user/model/User.java
@@ -73,4 +73,8 @@ public class User {
     public void updateGithubAccessToken(String githubAccessToken) {
         this.githubAccessToken = githubAccessToken;
     }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/interviewai/backend/user/service/UserService.java
+++ b/src/main/java/com/interviewai/backend/user/service/UserService.java
@@ -5,4 +5,6 @@ import com.interviewai.backend.user.controller.dto.UserProfileResponseDto;
 public interface UserService {
 
     UserProfileResponseDto findUserProfile(Long userId);
+
+    void changePassword(Long userId, String currentPassword, String newPassword, String confirmNewPassword);
 }

--- a/src/main/java/com/interviewai/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/user/service/UserServiceImpl.java
@@ -2,10 +2,12 @@ package com.interviewai.backend.user.service;
 
 import com.interviewai.backend.global.common.exception.BusinessException;
 import com.interviewai.backend.user.controller.dto.UserProfileResponseDto;
+import com.interviewai.backend.user.enums.OAuthProvider;
 import com.interviewai.backend.user.enums.UserErrorCode;
 import com.interviewai.backend.user.model.User;
 import com.interviewai.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,11 +17,37 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserProfileResponseDto findUserProfile(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         return UserProfileResponseDto.from(user);
+    }
+
+    @Override
+    @Transactional
+    public void changePassword(Long userId, String currentPassword, String newPassword, String confirmNewPassword) {
+        if (!newPassword.equals(confirmNewPassword)) {
+            throw new BusinessException(UserErrorCode.CONFIRM_PASSWORD_MISMATCH);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.getProvider() != OAuthProvider.LOCAL || user.getPassword() == null) {
+            throw new BusinessException(UserErrorCode.PASSWORD_CHANGE_NOT_SUPPORTED);
+        }
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new BusinessException(UserErrorCode.CURRENT_PASSWORD_MISMATCH);
+        }
+
+        if (currentPassword.equals(newPassword)) {
+            throw new BusinessException(UserErrorCode.NEW_PASSWORD_SAME_AS_CURRENT);
+        }
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/src/test/java/com/interviewai/backend/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/auth/service/AuthServiceImplTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -31,6 +32,9 @@ class AuthServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("기능_테스트_유효한_리프레시_토큰으로_새_토큰을_발급한다")
@@ -89,6 +93,138 @@ class AuthServiceImplTest {
         assertThatThrownBy(() -> authService.refreshToken(refreshToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("사용자");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_이메일_회원가입에_성공한다")
+    void 기능_테스트_이메일_회원가입에_성공한다() {
+        // given
+        String email = "user@test.com";
+        String password = "password123";
+        String name = "테스트유저";
+        String encodedPassword = "encoded_password";
+
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        given(passwordEncoder.encode(password)).willReturn(encodedPassword);
+        given(userRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(jwtProvider.generateAccessToken(any(), any())).willReturn("access.token");
+        given(jwtProvider.generateRefreshToken(any())).willReturn("refresh.token");
+
+        // when
+        AuthTokenServiceDto result = authService.signup(email, password, password, name);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("access.token");
+        assertThat(result.getRefreshToken()).isEqualTo("refresh.token");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_비밀번호_확인이_일치하지_않으면_예외가_발생한다")
+    void 예외_테스트_비밀번호_확인이_일치하지_않으면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> authService.signup("user@test.com", "password123", "different", "유저"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("비밀번호 확인이 일치하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_이메일이_중복되면_예외가_발생한다")
+    void 예외_테스트_이메일이_중복되면_예외가_발생한다() {
+        // given
+        String email = "existing@test.com";
+        User existingUser = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email(email)
+                .name("기존유저")
+                .role(UserRole.USER)
+                .build();
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(existingUser));
+
+        // when & then
+        assertThatThrownBy(() -> authService.signup(email, "password123", "password123", "새유저"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이미 등록된 이메일");
+    }
+
+    @Test
+    @DisplayName("기능_테스트_이메일_로그인에_성공한다")
+    void 기능_테스트_이메일_로그인에_성공한다() {
+        // given
+        String email = "user@test.com";
+        String password = "password123";
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email(email)
+                .name("테스트유저")
+                .password("encoded_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(password, "encoded_password")).willReturn(true);
+        given(jwtProvider.generateAccessToken(any(), any())).willReturn("access.token");
+        given(jwtProvider.generateRefreshToken(any())).willReturn("refresh.token");
+
+        // when
+        AuthTokenServiceDto result = authService.login(email, password);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("access.token");
+        assertThat(result.getRefreshToken()).isEqualTo("refresh.token");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_존재하지_않는_이메일로_로그인하면_예외가_발생한다")
+    void 예외_테스트_존재하지_않는_이메일로_로그인하면_예외가_발생한다() {
+        // given
+        given(userRepository.findByEmail("none@test.com")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("none@test.com", "password123"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_비밀번호가_틀리면_예외가_발생한다")
+    void 예외_테스트_비밀번호가_틀리면_예외가_발생한다() {
+        // given
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email("user@test.com")
+                .name("테스트유저")
+                .password("encoded_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findByEmail("user@test.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong_password", "encoded_password")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("user@test.com", "wrong_password"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_OAuth_사용자가_이메일_로그인을_시도하면_예외가_발생한다")
+    void 예외_테스트_OAuth_사용자가_이메일_로그인을_시도하면_예외가_발생한다() {
+        // given
+        User oauthUser = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("github@test.com")
+                .name("깃허브유저")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findByEmail("github@test.com")).willReturn(Optional.of(oauthUser));
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("github@test.com", "password123"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
     }
 
     // Mockito argument matchers helper

--- a/src/test/java/com/interviewai/backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/user/service/UserServiceImplTest.java
@@ -13,12 +13,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -28,6 +30,9 @@ class UserServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("기능_테스트_유저_프로필_조회에_성공한다")
@@ -66,5 +71,117 @@ class UserServiceImplTest {
         assertThatThrownBy(() -> userService.findUserProfile(nonExistentUserId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("기능_테스트_비밀번호_변경에_성공한다")
+    void 기능_테스트_비밀번호_변경에_성공한다() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email("user@test.com")
+                .name("테스트유저")
+                .password("encoded_old_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("oldPassword1", "encoded_old_password")).willReturn(true);
+        given(passwordEncoder.encode("newPassword1")).willReturn("encoded_new_password");
+
+        // when
+        userService.changePassword(userId, "oldPassword1", "newPassword1", "newPassword1");
+
+        // then
+        verify(passwordEncoder).encode("newPassword1");
+        assertThat(user.getPassword()).isEqualTo("encoded_new_password");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_새_비밀번호_확인이_일치하지_않으면_예외가_발생한다")
+    void 예외_테스트_새_비밀번호_확인이_일치하지_않으면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(1L, "oldPassword1", "newPassword1", "different"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("비밀번호 확인이 일치하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_OAuth_사용자가_비밀번호_변경을_시도하면_예외가_발생한다")
+    void 예외_테스트_OAuth_사용자가_비밀번호_변경을_시도하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        User oauthUser = User.builder()
+                .providerId("12345")
+                .provider(OAuthProvider.GITHUB)
+                .email("github@test.com")
+                .name("깃허브유저")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(oauthUser));
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(userId, "password", "newPass1", "newPass1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("비밀번호 변경을 지원하지 않는 계정");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_현재_비밀번호가_틀리면_예외가_발생한다")
+    void 예외_테스트_현재_비밀번호가_틀리면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email("user@test.com")
+                .name("테스트유저")
+                .password("encoded_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrongPassword", "encoded_password")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(userId, "wrongPassword", "newPass1", "newPass1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("현재 비밀번호가 일치하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_새_비밀번호가_현재_비밀번호와_동일하면_예외가_발생한다")
+    void 예외_테스트_새_비밀번호가_현재_비밀번호와_동일하면_예외가_발생한다() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .provider(OAuthProvider.LOCAL)
+                .email("user@test.com")
+                .name("테스트유저")
+                .password("encoded_password")
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("samePass1", "encoded_password")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(userId, "samePass1", "samePass1", "samePass1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("새 비밀번호가 현재 비밀번호와 동일");
+    }
+
+    @Test
+    @DisplayName("예외_테스트_비밀번호_변경_시_사용자가_존재하지_않으면_예외가_발생한다")
+    void 예외_테스트_비밀번호_변경_시_사용자가_존재하지_않으면_예외가_발생한다() {
+        // given
+        Long nonExistentUserId = 999L;
+        given(userRepository.findById(nonExistentUserId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(nonExistentUserId, "old", "newPass1", "newPass1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다");
     }
 }


### PR DESCRIPTION
## Summary
- 이메일 가입 사용자를 위한 비밀번호 변경 API 추가 (`PATCH /api/users/me/password`)
- 현재 비밀번호 확인 필수, OAuth 사용자 차단, 새 비밀번호 == 현재 비밀번호 차단
- 비밀번호 복잡도 검증 (영문+숫자, 8~20자)

> **Note**: 이 PR은 #78 (이메일 인증)이 머지된 후 머지해야 합니다.

## Test plan
- [ ] `PATCH /api/users/me/password` — 정상 변경 시 200
- [ ] 현재 비밀번호 틀림 → 400
- [ ] 새 비밀번호 == 현재 비밀번호 → 400
- [ ] confirmNewPassword 불일치 → 400
- [ ] OAuth 사용자가 비밀번호 변경 시도 → 400
- [ ] 인증 없이 접근 → 401

Closes #79