### PR TITLE
feat(#83): Refresh Token 로테이션 구현

### DIFF
--- a/src/main/java/com/interviewai/backend/auth/model/RefreshToken.java
+++ b/src/main/java/com/interviewai/backend/auth/model/RefreshToken.java
@@ -1,0 +1,41 @@
+package com.interviewai.backend.auth.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/interviewai/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/interviewai/backend/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,27 @@
+package com.interviewai.backend.auth.repository;
+
+import com.interviewai.backend.auth.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.token = :token")
+    void deleteByToken(@Param("token") String token);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :now")
+    void deleteAllExpired(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/interviewai/backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/interviewai/backend/auth/service/AuthServiceImpl.java
@@ -1,8 +1,11 @@
 package com.interviewai.backend.auth.service;
 
 import com.interviewai.backend.auth.enums.AuthErrorCode;
+import com.interviewai.backend.auth.model.RefreshToken;
+import com.interviewai.backend.auth.repository.RefreshTokenRepository;
 import com.interviewai.backend.auth.service.dto.AuthTokenServiceDto;
 import com.interviewai.backend.global.common.exception.BusinessException;
+import com.interviewai.backend.global.config.JwtProperties;
 import com.interviewai.backend.global.config.jwt.JwtProvider;
 import com.interviewai.backend.user.enums.UserErrorCode;
 import com.interviewai.backend.user.model.User;
@@ -11,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,23 +23,45 @@ public class AuthServiceImpl implements AuthService {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProperties jwtProperties;
 
     @Override
+    @Transactional(noRollbackFor = BusinessException.class)
     public AuthTokenServiceDto refreshToken(String refreshToken) {
         if (!jwtProvider.validateToken(refreshToken)) {
             throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
         }
 
         Long userId = jwtProvider.getUserId(refreshToken);
+
+        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken).orElse(null);
+        if (storedToken == null) {
+            refreshTokenRepository.deleteAllByUserId(userId);
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        refreshTokenRepository.deleteByToken(storedToken.getToken());
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
-        String newRefreshToken = jwtProvider.generateRefreshToken(user.getId());
+        return generateTokenPairAndSave(user);
+    }
+
+    private AuthTokenServiceDto generateTokenPairAndSave(User user) {
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(user.getId())
+                .token(refreshToken)
+                .expiresAt(LocalDateTime.now().plusSeconds(jwtProperties.getRefreshExpiration() / 1000))
+                .build());
 
         return AuthTokenServiceDto.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/interviewai/backend/global/config/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/interviewai/backend/global/config/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,8 @@
 package com.interviewai.backend.global.config.oauth;
 
+import com.interviewai.backend.auth.model.RefreshToken;
+import com.interviewai.backend.auth.repository.RefreshTokenRepository;
+import com.interviewai.backend.global.config.JwtProperties;
 import com.interviewai.backend.global.config.jwt.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,9 +12,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -19,17 +24,27 @@ import java.io.IOException;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProperties jwtProperties;
 
     @Value("${app.frontend-url:http://localhost:5173}")
     private String frontendUrl;
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
         String accessToken = jwtProvider.generateAccessToken(oAuth2User.getUserId(), oAuth2User.getEmail());
         String refreshToken = jwtProvider.generateRefreshToken(oAuth2User.getUserId());
+
+        refreshTokenRepository.deleteAllByUserId(oAuth2User.getUserId());
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(oAuth2User.getUserId())
+                .token(refreshToken)
+                .expiresAt(LocalDateTime.now().plusSeconds(jwtProperties.getRefreshExpiration() / 1000))
+                .build());
 
         String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/auth/callback")
                 .queryParam("accessToken", accessToken)

--- a/src/test/java/com/interviewai/backend/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/interviewai/backend/auth/service/AuthServiceImplTest.java
@@ -1,7 +1,10 @@
 package com.interviewai.backend.auth.service;
 
+import com.interviewai.backend.auth.model.RefreshToken;
+import com.interviewai.backend.auth.repository.RefreshTokenRepository;
 import com.interviewai.backend.auth.service.dto.AuthTokenServiceDto;
 import com.interviewai.backend.global.common.exception.BusinessException;
+import com.interviewai.backend.global.config.JwtProperties;
 import com.interviewai.backend.global.config.jwt.JwtProvider;
 import com.interviewai.backend.user.enums.OAuthProvider;
 import com.interviewai.backend.user.enums.UserRole;
@@ -14,11 +17,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceImplTest {
@@ -31,6 +37,12 @@ class AuthServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProperties jwtProperties;
 
     @Test
     @DisplayName("기능_테스트_유효한_리프레시_토큰으로_새_토큰을_발급한다")
@@ -46,12 +58,20 @@ class AuthServiceImplTest {
                 .profileImageUrl(null)
                 .role(UserRole.USER)
                 .build();
+        RefreshToken storedToken = RefreshToken.builder()
+                .userId(userId)
+                .token(refreshToken)
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
 
         given(jwtProvider.validateToken(refreshToken)).willReturn(true);
         given(jwtProvider.getUserId(refreshToken)).willReturn(userId);
+        given(refreshTokenRepository.findByToken(refreshToken)).willReturn(Optional.of(storedToken));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(jwtProvider.generateAccessToken(any(), any())).willReturn("new.access.token");
         given(jwtProvider.generateRefreshToken(any())).willReturn("new.refresh.token");
+        given(jwtProperties.getRefreshExpiration()).willReturn(604800000L);
+        given(refreshTokenRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
         // when
         AuthTokenServiceDto result = authService.refreshToken(refreshToken);
@@ -59,6 +79,8 @@ class AuthServiceImplTest {
         // then
         assertThat(result.getAccessToken()).isEqualTo("new.access.token");
         assertThat(result.getRefreshToken()).isEqualTo("new.refresh.token");
+        verify(refreshTokenRepository).deleteByToken(refreshToken);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 
     @Test
@@ -80,9 +102,15 @@ class AuthServiceImplTest {
         // given
         String refreshToken = "valid.refresh.token";
         Long nonExistentUserId = 999L;
+        RefreshToken storedToken = RefreshToken.builder()
+                .userId(nonExistentUserId)
+                .token(refreshToken)
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
 
         given(jwtProvider.validateToken(refreshToken)).willReturn(true);
         given(jwtProvider.getUserId(refreshToken)).willReturn(nonExistentUserId);
+        given(refreshTokenRepository.findByToken(refreshToken)).willReturn(Optional.of(storedToken));
         given(userRepository.findById(nonExistentUserId)).willReturn(Optional.empty());
 
         // when & then
@@ -91,8 +119,22 @@ class AuthServiceImplTest {
                 .hasMessageContaining("사용자");
     }
 
-    // Mockito argument matchers helper
-    private static <T> T any() {
-        return org.mockito.ArgumentMatchers.any();
+    @Test
+    @DisplayName("예외_테스트_DB에_없는_리프레시_토큰이면_해당_유저의_모든_토큰을_삭제하고_예외가_발생한다")
+    void 예외_테스트_DB에_없는_리프레시_토큰이면_해당_유저의_모든_토큰을_삭제하고_예외가_발생한다() {
+        // given
+        String stolenToken = "stolen.refresh.token";
+        Long userId = 1L;
+
+        given(jwtProvider.validateToken(stolenToken)).willReturn(true);
+        given(jwtProvider.getUserId(stolenToken)).willReturn(userId);
+        given(refreshTokenRepository.findByToken(stolenToken)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(stolenToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("유효하지 않은 토큰");
+        verify(refreshTokenRepository).deleteAllByUserId(userId);
     }
+
 }

--- a/src/test/java/com/interviewai/backend/global/config/oauth/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/oauth/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,5 +1,8 @@
 package com.interviewai.backend.global.config.oauth;
 
+import com.interviewai.backend.auth.model.RefreshToken;
+import com.interviewai.backend.auth.repository.RefreshTokenRepository;
+import com.interviewai.backend.global.config.JwtProperties;
 import com.interviewai.backend.global.config.jwt.JwtProvider;
 import com.interviewai.backend.user.enums.OAuthProvider;
 import com.interviewai.backend.user.enums.UserRole;
@@ -32,6 +35,12 @@ class OAuth2AuthenticationSuccessHandlerTest {
     private JwtProvider jwtProvider;
 
     @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    @Mock
     private HttpServletRequest request;
 
     @Mock
@@ -44,7 +53,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
     @BeforeEach
     void setUp() {
-        handler = new OAuth2AuthenticationSuccessHandler(jwtProvider);
+        handler = new OAuth2AuthenticationSuccessHandler(jwtProvider, refreshTokenRepository, jwtProperties);
         ReflectionTestUtils.setField(handler, "frontendUrl", "http://localhost:5173");
     }
 
@@ -63,6 +72,8 @@ class OAuth2AuthenticationSuccessHandlerTest {
         when(authentication.getPrincipal()).thenReturn(oAuth2User);
         when(jwtProvider.generateAccessToken(any(), any())).thenReturn("test-access-token");
         when(jwtProvider.generateRefreshToken(any())).thenReturn("test-refresh-token");
+        when(jwtProperties.getRefreshExpiration()).thenReturn(604800000L);
+        when(refreshTokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(response.encodeRedirectURL(any())).thenAnswer(inv -> inv.getArgument(0));
 
         handler.onAuthenticationSuccess(request, response, authentication);
@@ -74,5 +85,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
                 .contains("http://localhost:5173/auth/callback")
                 .contains("accessToken=test-access-token")
                 .contains("refreshToken=test-refresh-token");
+        verify(refreshTokenRepository).deleteAllByUserId(any());
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 }


### PR DESCRIPTION
## Summary
- RefreshToken 엔티티 + Repository 추가 (PostgreSQL 저장)
- 토큰 갱신 시 로테이션: 기존 토큰 폐기 → 새 토큰 발급 + DB 저장
- 탈취 감지: DB에 없는 토큰으로 갱신 시도 시 해당 유저의 모든 토큰 삭제
- OAuth2 재로그인 시 기존 토큰 삭제 후 새 토큰 저장
- 만료 토큰 정리용 벌크 삭제 쿼리 포함

## Test plan
- [ ] 로그인 → refresh API 호출 → 새 토큰 쌍 반환, 이전 refresh token 무효화
- [ ] 이전 refresh token으로 재호출 → 401 + 해당 유저 모든 토큰 삭제
- [ ] OAuth2 재로그인 시 이전 refresh token 무효화 확인
- [ ] 기존 API 정상 동작 확인

Closes #83