### PR TITLE
feat(#85): CORS AllowedHeaders 제한 및 Actuator 접근 제한

### DIFF
--- a/src/main/java/com/interviewai/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/interviewai/backend/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers("/api/auth/**", "/oauth2/**", "/login/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/actuator/health", "/actuator/prometheus").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -59,7 +59,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(corsProperties.getAllowedOrigins());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/test/java/com/interviewai/backend/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/interviewai/backend/global/config/SecurityConfigTest.java
@@ -66,6 +66,17 @@ class SecurityConfigTest {
     }
 
     @Test
+    @DisplayName("기능_테스트_corsConfigurationSource_허용된_헤더가_명시적으로_설정된다")
+    void 기능_테스트_corsConfigurationSource_허용된_헤더가_명시적으로_설정된다() {
+        CorsConfigurationSource source = securityConfig.corsConfigurationSource();
+
+        CorsConfiguration config = ((UrlBasedCorsConfigurationSource) source)
+                .getCorsConfiguration(mockRequest("/api/test"));
+        assertThat(config.getAllowedHeaders())
+                .containsExactlyInAnyOrder("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With");
+    }
+
+    @Test
     @DisplayName("기능_테스트_corsConfigurationSource_credentials_허용이_설정된다")
     void 기능_테스트_corsConfigurationSource_credentials_허용이_설정된다() {
         CorsConfigurationSource source = securityConfig.corsConfigurationSource();


### PR DESCRIPTION
## Summary
- CORS `allowedHeaders`를 `*` → 필요한 헤더만 명시적 허용 (Authorization, Content-Type, Accept, Origin, X-Requested-With)
- Actuator `/prometheus` 엔드포인트를 인증 필수로 변경 (health만 공개 유지)

## Test plan
- [ ] 프론트엔드에서 API 호출 시 CORS 에러 없이 정상 동작
- [ ] `/actuator/health` — 미인증 접근 가능
- [ ] `/actuator/prometheus` — 미인증 접근 시 401
- [ ] 기존 API 정상 동작 확인

Closes #85